### PR TITLE
Split metrics reporting from collection, default the debug channel off, and narrow the editor tooling switch

### DIFF
--- a/addons/Nebula/Core/Bots/README.md
+++ b/addons/Nebula/Core/Bots/README.md
@@ -95,3 +95,9 @@ MTU-exceeded / ack-timeout counters. Recording is allocation-free so that measur
 perturb what is measured. This goes to stdout rather than the debug channel deliberately —
 `DebugHub` only produces frames while a debugger is attached and drops lossy frames when its queue
 backs up, which would lose exactly the samples a loaded run exists to capture.
+
+Collection and console output are separate switches. `--metrics` turns on both; the
+`NEBULA_PERFORMANCE` environment variable (or a line in `res://.env.server`) turns on collection
+and the debug-channel copy the editor's **Performance** tab reads, but prints nothing. Use the env
+var in the editor, where a line per world per second is noise; use `--metrics` for a headless soak,
+where nothing is attached to read the debug channel and an unprinted line does not exist.

--- a/addons/Nebula/Core/Diagnostics/ServerMetrics.cs
+++ b/addons/Nebula/Core/Diagnostics/ServerMetrics.cs
@@ -13,23 +13,42 @@ namespace Nebula.Diagnostics
     /// are plain field writes and the tick samples land in a preallocated ring. Only the once-per-
     /// interval emit builds a string, through a reused builder.</para>
     ///
-    /// <para>Goes to stdout rather than the debug channel on purpose: DebugHub only produces frames
-    /// while a debugger is attached and drops lossy ones when its queue backs up, which would lose
-    /// exactly the samples a loaded run exists to capture.</para>
+    /// <para>Collection and REPORTING are separate switches. Every enabled run ships its line to
+    /// any attached debugger for the editor's Performance tab; only a run started with
+    /// <see cref="EnableArg"/> also writes it to stdout. That split exists because the two callers
+    /// want opposite things: a headless soak has no debugger attached and stdout is the only place
+    /// its numbers can land, whereas an editor session has the Performance tab already and does not
+    /// want a line per world per second in its console.</para>
+    ///
+    /// <para>Stdout rather than the debug channel is the right carrier for the soak case: DebugHub
+    /// only produces frames while a debugger is attached and drops lossy ones when its queue backs
+    /// up, which would lose exactly the samples a loaded run exists to capture.</para>
     /// </summary>
     public sealed class ServerMetrics
     {
+        /// <summary>
+        /// Enables metrics AND the stdout line. This is the switch a headless soak wants:
+        /// nothing is attached to read the debug channel, so a line that is not printed is
+        /// a line that does not exist. ImpairedSoakTests scrapes those lines, so removing
+        /// the print from this path breaks a real assertion.
+        /// </summary>
         public const string EnableArg = "--metrics";
+
         public const string IntervalArg = "--metricsInterval=";
 
         /// <summary>
-        /// Environment variable that enables metrics like <see cref="EnableArg"/> does.
-        /// Read through the Env autoload, so it works both as a real process variable
+        /// Environment variable that enables metrics WITHOUT the stdout line — collection
+        /// and the debug-channel copy the editor's Performance tab reads, nothing in the
+        /// console. That is the whole difference from <see cref="EnableArg"/>: this is how
+        /// an ordinary editor session opts in, and one JSON line per world per second is
+        /// noise there, not data.
+        ///
+        /// <para>Read through the Env autoload, so it works both as a real process variable
         /// (spawned processes inherit the editor's environment) and as an entry in the
         /// process's .env file (res://.env.server for servers). This gates the SERVER
         /// only - collection and reporting cost nothing unless it is set, so production
         /// instances leave it off. The editor's Performance tab always exists and simply
-        /// stays empty when no server is reporting.
+        /// stays empty when no server is reporting.</para>
         /// </summary>
         public const string EnableEnvVar = "NEBULA_PERFORMANCE";
 
@@ -41,6 +60,7 @@ namespace Nebula.Diagnostics
 
         private static bool _parsed;
         private static bool _enabled;
+        private static bool _writesToStdout;
         private static double _intervalSeconds = 1.0;
 
         /// <summary>Whether metrics were requested on the command line. Parsed once.</summary>
@@ -50,6 +70,21 @@ namespace Nebula.Diagnostics
             {
                 ParseArgs();
                 return _enabled;
+            }
+        }
+
+        /// <summary>
+        /// Whether the emitted line is also printed to stdout. True only when
+        /// <see cref="EnableArg"/> was passed; enabling through
+        /// <see cref="EnableEnvVar"/> alone keeps the console quiet and reports over the
+        /// debug channel only.
+        /// </summary>
+        public static bool WritesToStdout
+        {
+            get
+            {
+                ParseArgs();
+                return _writesToStdout;
             }
         }
 
@@ -76,6 +111,9 @@ namespace Nebula.Diagnostics
                 if (argument == EnableArg)
                 {
                     _enabled = true;
+                    // The command-line switch is what asks for console output; the env var
+                    // deliberately does not.
+                    _writesToStdout = true;
                 }
                 else if (argument.StartsWith(IntervalArg))
                 {
@@ -275,10 +313,13 @@ namespace Nebula.Diagnostics
             _line.Append(",\"spawn_backlog_max\":").Append(_spawnBacklogMax).Append('}');
             _line.Append('}');
 
-            // Stdout, as the class doc promises: the DebugHub copy the caller also ships
-            // only exists while a debugger is attached, so without this a headless soak
-            // (the exact case metrics exist for) produces no metrics at all.
-            Godot.GD.Print(_line.ToString());
+            // Only for a run started with --metrics. The DebugHub copy the caller ships
+            // exists only while a debugger is attached, so a headless soak - the exact case
+            // that passes --metrics - would otherwise produce no metrics at all. An editor
+            // session enabled through NEBULA_PERFORMANCE has the Performance tab reading
+            // that copy already and gets no console line.
+            if (WritesToStdout)
+                Godot.GD.Print(_line.ToString());
 
             string json = _line.ToString(LinePrefix.Length, _line.Length - LinePrefix.Length);
 

--- a/addons/Nebula/Core/NetRunner.cs
+++ b/addons/Nebula/Core/NetRunner.cs
@@ -241,16 +241,21 @@ namespace Nebula
 
         /// <summary>
         /// Environment/.env switch for <see cref="DebugServerEnabled"/>, checked before
-        /// the project setting so a deployment can turn the channel off per process kind
-        /// (<c>.env.server</c> vs <c>.env.client</c>) without editing project.godot.
+        /// the project setting so a deployment can turn the channel on or off per process
+        /// kind (<c>.env.server</c> vs <c>.env.client</c>) without editing project.godot.
         /// Off means fully inert: no listener, no frames built, no per-tick debug work.
+        ///
+        /// <para>OFF unless something says otherwise — <c>NEBULA_DEBUG=1</c>, or the project
+        /// setting turned on deliberately. It used to default ON, which meant every process
+        /// handed a <c>--debugPort</c> got a debug channel whether or not the project had
+        /// ever opted in.</para>
         /// </summary>
         public const string DEBUG_SERVER_ENV_VAR = "NEBULA_DEBUG";
 
         private static bool ResolveDebugServerEnabled()
             => Env.TryGetFlag(DEBUG_SERVER_ENV_VAR, out bool fromEnv)
                 ? fromEnv
-                : ProjectSettings.GetSetting(DEBUG_SERVER_SETTING, true).AsBool();
+                : ProjectSettings.GetSetting(DEBUG_SERVER_SETTING, false).AsBool();
 
         /// <summary>Project setting key for <see cref="DebugServerEnabled"/>.</summary>
         public const string DEBUG_SERVER_SETTING = "Nebula/config/debug/enable_debug_server";

--- a/addons/Nebula/Testing/Integration/GodotProcess.cs
+++ b/addons/Nebula/Testing/Integration/GodotProcess.cs
@@ -120,6 +120,13 @@ public sealed class GodotProcess : IDisposable
             WorkingDirectory = workingDirectory ?? Environment.CurrentDirectory
         };
 
+        // Every process this harness starts is driven through the debug channel, so it
+        // asks for one rather than inheriting whatever the project happens to default to.
+        // The process environment wins over the project's .env files (see Env.GetValue),
+        // which also stops a checked-in "NEBULA_DEBUG=0" in .env.server from quietly
+        // costing a test its debug events.
+        startInfo.Environment["NEBULA_DEBUG"] = "1";
+
         var process = new Process { StartInfo = startInfo };
 
         if (!process.Start())

--- a/addons/Nebula/Testing/Integration/ImpairedSoakTests.cs
+++ b/addons/Nebula/Testing/Integration/ImpairedSoakTests.cs
@@ -65,7 +65,9 @@ public class ImpairedSoakTests : IntegrationTestBase
             WorldId = worldId,
             InitialWorldScene = WorldScene,
             DebugPort = SoakServerDebugPort,
-            // One JSON line per interval on stdout; the assertions below read it.
+            // One JSON line per interval on stdout; the assertions below scrape it. It has to
+            // be the --metrics ARG specifically — NEBULA_PERFORMANCE enables collection and the
+            // debug-channel copy but prints nothing, and nothing here reads that copy.
             ExtraArgs = { ["metrics"] = "" },
         });
 

--- a/addons/Nebula/Tools/Debugger/NebulaDebugView.cs
+++ b/addons/Nebula/Tools/Debugger/NebulaDebugView.cs
@@ -184,11 +184,17 @@ namespace Nebula.Internal.Editor
             targetPorts.Clear();
 
             var orchestrator = EditorInterface.Singleton.GetBaseControl().GetNodeOrNull(ORCHESTRATOR_NODE_NAME);
-            // Read live rather than through NetRunner.DebugServerEnabled, which caches
-            // for the lifetime of a run: in the editor the setting can be toggled at
-            // any time and the tab should reflect it immediately.
-            if (IsDebugServerEnabled
-                && orchestrator is not null && orchestrator.Call("is_running").AsBool())
+            // Deliberately NOT gated on the debug-server setting. That setting governs the
+            // SPAWNED PROCESSES, and it is only their fallback — NEBULA_DEBUG in the
+            // process's own .env overrides it, per process kind, so the editor cannot know
+            // from here whether a given instance will produce frames. Worse, the same
+            // socket also carries METRICS, which NEBULA_PERFORMANCE governs independently:
+            // gating the reader on the debug switch made the Performance tab go blank
+            // whenever the debugger was off, which is exactly the combination its own
+            // placeholder advertises as supported. Attaching costs an async connect per
+            // port per retry interval, and "nothing listening yet" is already the normal
+            // case during a launch.
+            if (orchestrator is not null && orchestrator.Call("is_running").AsBool())
             {
                 foreach (int port in orchestrator.Call("get_debug_ports").AsInt32Array())
                 {
@@ -210,13 +216,6 @@ namespace Nebula.Internal.Editor
             UpdatePlaceholder();
         }
 
-        /// <summary>
-        /// Whether the debug channel is switched on for this project. Uncached so a
-        /// toggle in Project Settings shows up without an editor restart.
-        /// </summary>
-        private static bool IsDebugServerEnabled =>
-            ProjectSettings.GetSetting(NetRunner.DEBUG_SERVER_SETTING, true).AsBool();
-
         public override void _Process(double delta)
         {
             // Drains regardless of visibility. An attached-but-undrained socket fills
@@ -224,14 +223,6 @@ namespace Nebula.Internal.Editor
             // which is unrecoverable for the session — so "the user switched tabs" must
             // never stop the reader. (This also can't be delegated to a flag set from
             // outside: assembly reloads reset plain fields without re-running _Ready.)
-
-            if (!IsDebugServerEnabled)
-            {
-                // Nothing is listening, so don't sit in a connect-retry loop. Any
-                // connections from before the toggle are dropped by RefreshSessionTargets.
-                RefreshSessionTargets();
-                return;
-            }
 
             DrainConnections();
 
@@ -557,13 +548,14 @@ namespace Nebula.Internal.Editor
             if (worldSelector is not null)
                 worldSelector.GetParent<Control>().Visible = !empty;
 
-            // Distinguish "switched off" from "nothing running" — otherwise the tab
-            // tells you to press Play, which would never produce anything.
+            // One message covering both empty cases. It used to read the project setting
+            // and claim "Debug Server Disabled", but that setting is only the spawned
+            // processes' FALLBACK — a process whose .env sets NEBULA_DEBUG=1 reports
+            // regardless — so the editor cannot tell the two apart and should say what to
+            // check instead of asserting a cause.
             if (empty)
             {
-                placeholder.Text = IsDebugServerEnabled
-                    ? "No worlds — press Play in the toolbar."
-                    : "Debug Server Disabled";
+                placeholder.Text = "Enable NEBULA_DEBUG=true in your .env and run your game.\n";
             }
         }
 

--- a/addons/Nebula/Tools/Main.cs
+++ b/addons/Nebula/Tools/Main.cs
@@ -18,14 +18,15 @@ using Nebula.Serialization;
 [Tool]
 public partial class Main : EditorPlugin
 {
-    public const string DISABLE_TOOLING_SETTING = "Nebula/config/editor/disable_tooling";
+    public const string DISABLE_PLAY_BUTTON_SETTING = "Nebula/config/editor/disable_play_button";
 
     /// <summary>
-    /// Master switch (project setting): when true, none of the Nebula editor
-    /// tooling is set up — no tab, no play controls, no run-bar hiding,
-    /// no headless run-instances config. Editor restart required to apply.
+    /// Project setting: when true, the Nebula Play button and its configuration
+    /// dropdown are not created. Nothing else is affected — the debugger tab,
+    /// the dock and the inspector plugin still load, and Godot's own run bar is
+    /// always left exactly as the user has it. Editor restart required to apply.
     /// </summary>
-    private static bool ToolingDisabled => ProjectSettings.GetSetting(DISABLE_TOOLING_SETTING, false).AsBool();
+    private static bool PlayButtonDisabled => ProjectSettings.GetSetting(DISABLE_PLAY_BUTTON_SETTING, false).AsBool();
 
     private const string AUTOLOAD_RUNNER = "NetRunner";
     private const string AUTOLOAD_ENV = "Env";
@@ -45,12 +46,27 @@ public partial class Main : EditorPlugin
     private Button playButton;
     private MenuButton configDropdown;
     private NebulaConfigDialog configDialogInstance;
-    private Control editorRunBar;
+
+    /// <summary>
+    /// True when the play bar had to fall back to the documented toolbar
+    /// container because the editor run bar could not be located — teardown has
+    /// to use the matching removal call.
+    /// </summary>
+    private bool playBarUsesToolbarContainer;
 
     /// <summary>How often the play session's running state is re-checked, in seconds.</summary>
     private const double SESSION_POLL_INTERVAL = 0.25;
     private double sinceSessionPoll;
     private bool lastKnownSessionRunning;
+    private bool lastKnownNebulaActive;
+    private bool lastKnownEditorPlaying;
+
+    /// <summary>
+    /// Godot's built-in run bar, cached between visibility updates. Nebula hides
+    /// it only for the duration of a Nebula session — never on the strength of a
+    /// setting — and always puts it back in <see cref="_ExitTree"/>.
+    /// </summary>
+    private Control editorRunBar;
 
     private Control dockNetScenesInstance;
     private NetSceneInspector netSceneInspectorInstance;
@@ -65,7 +81,7 @@ public partial class Main : EditorPlugin
     /// <summary>
     /// Nebula owns a main-screen tab (the live network debugger).
     /// </summary>
-    public override bool _HasMainScreen() => !ToolingDisabled;
+    public override bool _HasMainScreen() => true;
 
     /// <summary>
     /// Shows or hides the Nebula main-screen tab.
@@ -107,33 +123,27 @@ public partial class Main : EditorPlugin
         projectSettingsController = new ProjectSettingsController();
         AddChild(projectSettingsController);
 
-        if (!ToolingDisabled)
-        {
-            // Main-screen tab (live network debugger)
-            CreateMainScreen(visible: false);
+        // Main-screen tab (live network debugger)
+        CreateMainScreen(visible: false);
 
-            // Top-bar play controls (Play/Stop + configuration dropdown)
+        // Top-bar play controls (Play/Stop + configuration dropdown)
+        if (!PlayButtonDisabled)
             CreatePlayBar();
 
-            // Re-attach to a session that outlived a plugin reload.
-            GetOrchestrator(createIfMissing: false);
-        }
+        // Re-attach to a session that outlived a plugin reload.
+        GetOrchestrator(createIfMissing: false);
 
-        // Editor-managed plays are only used to hold the debug server open for
-        // Nebula play sessions, so force a single headless run instance (or
-        // restore vanilla behavior when the tooling is disabled).
-        ApplyRunInstancesConfig();
+        // Deferred: the run bar is only findable once the editor UI is built.
+        CallDeferred(MethodName.ApplyPlayControlVisibility);
 
-        // Hide the built-in run bar (restore it when tooling is disabled);
-        // deferred so the editor UI is fully constructed, live-updated via
-        // settings_changed.
-        // IMPORTANT: name-bound Callable, NOT Callable.From. A delegate-backed
-        // callable parked on the immortal ProjectSettings singleton holds a
-        // GCHandle that pins the assembly on .NET reload (godot#78513): reloads
-        // skip _ExitTree, so such a connection is never released. Name-bound
-        // callables hold no managed state and re-resolve after reloads.
-        CallDeferred(MethodName.ApplyRunBarVisibility);
-        ProjectSettings.Singleton.Connect("settings_changed", new Callable(this, MethodName.ApplyRunBarVisibility));
+        // NOTE: Nebula never touches Godot's run bar or its Run Instances
+        // settings. An earlier version hid the run bar and rewrote the
+        // debug_options metadata on every editor start, which silently wiped
+        // whatever the project had configured under Debug -> Customize Run
+        // Instances. Nebula's own server/client/bot processes are spawned with
+        // OS.create_process and owe nothing to that machinery; the editor-managed
+        // play is only the debug-server holder, and NebulaDebugSession keeps
+        // itself to one visible-free instance on its own.
 
         // Dock: Network Scenes
         dockNetScenesInstance = DockNetScenes.Instantiate<Control>();
@@ -156,11 +166,8 @@ public partial class Main : EditorPlugin
     /// </summary>
     public override void _ExitTree()
     {
-        // Clean up (name-bound callables compare by object+method, so a freshly
-        // constructed one matches the stored connection even across reloads)
-        var settingsCallable = new Callable(this, MethodName.ApplyRunBarVisibility);
-        if (ProjectSettings.Singleton.IsConnected("settings_changed", settingsCallable))
-            ProjectSettings.Singleton.Disconnect("settings_changed", settingsCallable);
+        // Unconditional: the plugin can be disabled mid-session, and a run bar
+        // left hidden would be indistinguishable from a broken editor.
         if (editorRunBar is not null && GodotObject.IsInstanceValid(editorRunBar))
             editorRunBar.Visible = true;
         editorRunBar = null;
@@ -169,7 +176,7 @@ public partial class Main : EditorPlugin
 
         if (playBarInstance is not null)
         {
-            RemoveControlFromContainer(CustomControlContainer.Toolbar, playBarInstance);
+            DetachPlayBar();
             playBarInstance.QueueFree();
             playBarInstance = null;
             playButton = null;
@@ -244,8 +251,62 @@ public partial class Main : EditorPlugin
         popup.Connect(PopupMenu.SignalName.IndexPressed, new Callable(this, MethodName.OnConfigPopupIndexPressed));
         playBarInstance.AddChild(configDropdown);
 
-        AddControlToContainer(CustomControlContainer.Toolbar, playBarInstance);
+        AttachPlayBar();
         UpdatePlayButton();
+    }
+
+    /// <summary>
+    /// Parents the Nebula play bar immediately to the LEFT of Godot's built-in
+    /// run bar, so the two sets of play controls sit together with Nebula's
+    /// first. <c>AddControlToContainer(Toolbar, …)</c> appends to the end of the
+    /// title bar — past the renderer selector — which is why the placement is
+    /// done by hand here; it stays the fallback if the run bar can't be found.
+    /// </summary>
+    private void AttachPlayBar()
+    {
+        var anchor = FindPlayBarAnchor();
+        if (anchor?.GetParent() is not BoxContainer titleBar)
+        {
+            playBarUsesToolbarContainer = true;
+            AddControlToContainer(CustomControlContainer.Toolbar, playBarInstance);
+            return;
+        }
+
+        playBarUsesToolbarContainer = false;
+        titleBar.AddChild(playBarInstance);
+        // The bar was appended after the anchor, so the anchor's index is still
+        // the slot immediately before it.
+        titleBar.MoveChild(playBarInstance, anchor.GetIndex());
+    }
+
+    private void DetachPlayBar()
+    {
+        if (playBarUsesToolbarContainer)
+        {
+            RemoveControlFromContainer(CustomControlContainer.Toolbar, playBarInstance);
+            return;
+        }
+        playBarInstance.GetParent()?.RemoveChild(playBarInstance);
+    }
+
+    /// <summary>
+    /// The node to insert the play bar in front of: the run bar itself, or
+    /// whatever wrapper Godot has put around it, as long as that wrapper still
+    /// sits directly in a horizontal box. Climbing to the box is what keeps this
+    /// from becoming an unexpected second child of a single-child panel — the
+    /// run bar's immediate parent has changed shape between Godot releases.
+    /// </summary>
+    private static Control FindPlayBarAnchor()
+    {
+        const int MAX_WRAPPER_DEPTH = 3;
+        Node anchor = FindEditorRunBar(EditorInterface.Singleton.GetBaseControl());
+        for (int depth = 0; anchor is not null && depth <= MAX_WRAPPER_DEPTH; depth++)
+        {
+            if (anchor.GetParent() is BoxContainer)
+                return anchor as Control;
+            anchor = anchor.GetParent() as Control;
+        }
+        return null;
     }
 
     private void OnPlayBarReady()
@@ -540,34 +601,55 @@ public partial class Main : EditorPlugin
     private void OnOrchestratorStateChanged()
     {
         lastKnownSessionRunning = IsSessionRunning();
+        lastKnownNebulaActive = IsNebulaSessionActive();
+        lastKnownEditorPlaying = EditorInterface.Singleton.IsPlayingScene();
         UpdatePlayButton();
+        ApplyPlayControlVisibility();
         // The debugger tab attaches to / releases the session's debug ports.
         if (mainScreenInstance is not null && GodotObject.IsInstanceValid(mainScreenInstance))
             mainScreenInstance.OnSessionStateChanged();
     }
 
     /// <summary>
-    /// Forces editor-managed play to a single headless instance — its only
-    /// remaining job is the Nebula debug-server dummy session — or restores
-    /// vanilla run-instances behavior when the tooling is disabled. Note the
-    /// Run Instances dialog caches this metadata, so a change converges on the
-    /// next editor start.
+    /// Only one set of play controls is live at a time: a Nebula session hides
+    /// Godot's run bar until Nebula Stop, and a plain editor play hides Nebula's
+    /// bar until it ends. Neither is ever hidden while nothing is running — the
+    /// buttons belong to the user, and this is a transient mode, not a policy.
+    ///
+    /// <para>"The user pressed Godot's Play" has to be read as
+    /// <c>IsPlayingScene() &amp;&amp; !nebulaActive</c>, because a Nebula session
+    /// opens an editor play session of its own to hold the debug server; taking
+    /// IsPlayingScene at face value would hide Nebula's own Stop button the
+    /// instant it launched.</para>
+    ///
+    /// <para>The Nebula side keys off the orchestrator's <c>is_active</c> rather
+    /// than <c>is_running</c>: PlayCustomScene runs the C# build first, so there
+    /// is a multi-second window on a cold build where the session is unmistakably
+    /// a Nebula one but no instance process exists yet.</para>
     /// </summary>
-    private void ApplyRunInstancesConfig()
+    private void ApplyPlayControlVisibility()
     {
-        var editorSettings = EditorInterface.Singleton.GetEditorSettings();
-        bool disabled = ToolingDisabled;
-        var instance = new Godot.Collections.Dictionary
-        {
-            { "arguments", disabled ? "" : "--headless" },
-            { "features", "" },
-            { "override_args", !disabled },
-            { "override_features", false },
-        };
-        editorSettings.SetProjectMetadata("debug_options", "run_instances_config",
-            new Godot.Collections.Array { instance });
-        editorSettings.SetProjectMetadata("debug_options", "run_instance_count", 1);
-        editorSettings.SetProjectMetadata("debug_options", "multiple_instances_enabled", !disabled);
+        bool nebulaActive = IsNebulaSessionActive();
+        bool editorPlaying = EditorInterface.Singleton.IsPlayingScene() && !nebulaActive;
+
+        if (playBarInstance is not null && GodotObject.IsInstanceValid(playBarInstance))
+            playBarInstance.Visible = !editorPlaying;
+
+        if (editorRunBar is null || !GodotObject.IsInstanceValid(editorRunBar))
+            editorRunBar = FindEditorRunBar(EditorInterface.Singleton.GetBaseControl());
+        if (editorRunBar is not null)
+            editorRunBar.Visible = !nebulaActive;
+    }
+
+    /// <summary>
+    /// Whether a Nebula play session is live in the broad sense — launching,
+    /// running, or staggering its instances — as opposed to
+    /// <see cref="IsSessionRunning"/>, which only knows about spawned pids.
+    /// </summary>
+    private bool IsNebulaSessionActive()
+    {
+        var orchestrator = GetOrchestrator(createIfMissing: false);
+        return orchestrator is not null && orchestrator.Call("is_active").AsBool();
     }
 
     /// <summary>
@@ -582,9 +664,6 @@ public partial class Main : EditorPlugin
     /// </summary>
     public override void _Process(double delta)
     {
-        if (ToolingDisabled)
-            return;
-
         if (mainScreenInstance is null)
         {
             RebuildUiAfterAssemblyReload();
@@ -617,10 +696,17 @@ public partial class Main : EditorPlugin
             return;
         sinceSessionPoll = 0;
 
+        // Godot's own Play is pressed behind Nebula's back — there is no editor
+        // signal for it — so the editor's play state is polled alongside the
+        // session's rather than waited on.
         bool running = IsSessionRunning();
-        if (running == lastKnownSessionRunning)
+        bool active = IsNebulaSessionActive();
+        bool editorPlaying = EditorInterface.Singleton.IsPlayingScene();
+        if (running == lastKnownSessionRunning
+            && active == lastKnownNebulaActive
+            && editorPlaying == lastKnownEditorPlaying)
             return;
-        lastKnownSessionRunning = running;
+
         OnOrchestratorStateChanged();
     }
 
@@ -644,9 +730,13 @@ public partial class Main : EditorPlugin
         configDialogInstance = null;
 
         CreateMainScreen(wasVisible);
-        CreatePlayBar();
+        if (!PlayButtonDisabled)
+            CreatePlayBar();
         GetOrchestrator(createIfMissing: false);
-        CallDeferred(MethodName.ApplyRunBarVisibility);
+        // The reload happens INSIDE PlayCustomScene, i.e. exactly while the run
+        // bar is hidden for a launching session, so the rule has to be re-applied
+        // against the surviving orchestrator rather than assumed.
+        ApplyPlayControlVisibility();
     }
 
     private static void CollectNodesByName(Node root, string namePart, List<Node> results)
@@ -658,20 +748,15 @@ public partial class Main : EditorPlugin
     }
 
     /// <summary>
-    /// Shows/hides Godot's built-in run bar (Run … Movie Maker Mode) based on the
-    /// Nebula/config/editor/disable_tooling project setting. The run bar is an
-    /// internal editor node, so this reaches into the editor UI tree — the class
-    /// name check is the only unofficial dependency.
+    /// Locates Godot's built-in run bar (Run … Movie Maker Mode), which Nebula
+    /// parks its own play controls in front of and hides for the duration of a
+    /// Nebula session. It is never hidden on the strength of a project setting —
+    /// an earlier version did that, and the built-in buttons are not Nebula's to
+    /// take away. The run bar is an internal editor node, so this reaches into
+    /// the editor UI tree; the class name check is the only unofficial
+    /// dependency, and a miss costs the play bar its preferred position and
+    /// leaves both sets of controls visible.
     /// </summary>
-    private void ApplyRunBarVisibility()
-    {
-        if (editorRunBar is null || !GodotObject.IsInstanceValid(editorRunBar))
-            editorRunBar = FindEditorRunBar(EditorInterface.Singleton.GetBaseControl());
-        if (editorRunBar is null)
-            return;
-        editorRunBar.Visible = ToolingDisabled;
-    }
-
     private static Control FindEditorRunBar(Node node)
     {
         if (node.GetClass() == "EditorRunBar")

--- a/addons/Nebula/Tools/MainScreen/NebulaDebugSession.cs
+++ b/addons/Nebula/Tools/MainScreen/NebulaDebugSession.cs
@@ -1,6 +1,7 @@
 namespace Nebula.Tools;
 
 using Godot;
+using System.Text;
 
 /// <summary>
 /// Root of the dummy scene the Nebula plugin plays via PlayCustomScene to force
@@ -8,17 +9,151 @@ using Godot;
 /// can attach as debugger sessions. Does nothing but minimize its window and
 /// idle — it must stay alive as long as the attached sessions are wanted,
 /// because the editor closes the debug server when this session ends.
+///
+/// <para>Godot launches this scene once per configured run instance, and the
+/// project's Run Instances settings are the user's, not Nebula's — the plugin
+/// used to rewrite them to force a single headless instance, which silently
+/// wiped whatever the user had configured, on every editor start. The duplicates
+/// sort themselves out here instead: the process that wins
+/// <see cref="SINGLE_INSTANCE_PORT"/> is the holder, and the rest quit once they
+/// have confirmed who is holding it. Safe because
+/// <c>EditorRunBar::stop_child_process</c> only ends the play session once EVERY
+/// child process is gone, so the extras exiting does not close the debug
+/// server.</para>
 /// </summary>
 public partial class NebulaDebugSession : Node
 {
+    /// <summary>
+    /// Loopback port used purely as a single-instance lock — binding it is the
+    /// atomic "I am the holder" claim, and nothing is served over it beyond
+    /// <see cref="GreetingBytes"/>. Deliberately below both Linux's (32768+) and
+    /// macOS's (49152+) ephemeral ranges, so the OS never hands this port to one
+    /// of the Nebula debug channels that <c>Main.ReserveLoopbackPort</c> asks
+    /// for.
+    /// </summary>
+    private const int SINGLE_INSTANCE_PORT = 31415;
+
+    /// <summary>
+    /// Sent by the holder to anything that connects. A duplicate quits only once
+    /// it has read this back: without the check, an unrelated process happening
+    /// to hold the port would make EVERY instance quit, leaving nothing holding
+    /// the debug server open and no visible reason why.
+    /// </summary>
+    private static readonly byte[] GreetingBytes = Encoding.ASCII.GetBytes("NEBULA_DEBUG_SESSION\n");
+
+    /// <summary>
+    /// How long a duplicate waits for the holder's greeting before giving up and
+    /// staying alive. The bias is deliberate: a redundant minimized instance
+    /// costs some memory, whereas quitting when nobody else is holding the port
+    /// breaks the debugger for the entire play session.
+    /// </summary>
+    private const double GREETING_TIMEOUT_SECONDS = 2.0;
+
+    /// <summary>Held by the winning process for as long as it lives.</summary>
+    private TcpServer lockServer;
+
+    /// <summary>Non-null only while a duplicate is confirming who holds the port.</summary>
+    private StreamPeerTcp holderProbe;
+    private double sinceProbeStarted;
+
     public override void _Ready()
     {
-        GD.Print("NEBULA_DEBUG_SESSION: holding the editor debug server open.");
         var window = GetWindow();
         if (window is not null)
         {
             window.Title = "Nebula Debug Session";
             window.Mode = Window.ModeEnum.Minimized;
         }
+
+        SetProcess(true);
+
+        var server = new TcpServer();
+        if (server.Listen(SINGLE_INSTANCE_PORT, "127.0.0.1") == Error.Ok)
+        {
+            lockServer = server;
+            GD.Print("NEBULA_DEBUG_SESSION: holding the editor debug server open.");
+            return;
+        }
+
+        holderProbe = new StreamPeerTcp();
+        if (holderProbe.ConnectToHost("127.0.0.1", SINGLE_INSTANCE_PORT) == Error.Ok)
+            return;
+
+        holderProbe = null;
+        GD.Print("NEBULA_DEBUG_SESSION: single-instance port unreachable; staying alive.");
+    }
+
+    public override void _Process(double delta)
+    {
+        if (lockServer is not null)
+        {
+            GreetDuplicates();
+            return;
+        }
+        if (holderProbe is not null)
+            PollHolderProbe(delta);
+    }
+
+    public override void _ExitTree()
+    {
+        lockServer?.Stop();
+        lockServer = null;
+    }
+
+    /// <summary>
+    /// Answers every connection with the greeting and drops it — the connection
+    /// itself is the whole protocol.
+    /// </summary>
+    private void GreetDuplicates()
+    {
+        while (lockServer.IsConnectionAvailable())
+            lockServer.TakeConnection()?.PutData(GreetingBytes);
+    }
+
+    private void PollHolderProbe(double delta)
+    {
+        sinceProbeStarted += delta;
+        holderProbe.Poll();
+        var status = holderProbe.GetStatus();
+
+        if (status == StreamPeerTcp.Status.Connected && holderProbe.GetAvailableBytes() >= GreetingBytes.Length)
+        {
+            var result = holderProbe.GetData(GreetingBytes.Length);
+            bool greeted = (Error)result[0].AsInt32() == Error.Ok && IsGreeting(result[1].AsByteArray());
+            AbandonProbe();
+
+            if (greeted)
+            {
+                GD.Print("NEBULA_DEBUG_SESSION: another instance already holds the debug server; exiting.");
+                GetTree().Quit();
+                return;
+            }
+            GD.Print("NEBULA_DEBUG_SESSION: single-instance port answered by something else; staying alive.");
+            return;
+        }
+
+        if (status == StreamPeerTcp.Status.Error || sinceProbeStarted >= GREETING_TIMEOUT_SECONDS)
+        {
+            AbandonProbe();
+            GD.Print("NEBULA_DEBUG_SESSION: no Nebula holder answered; staying alive.");
+        }
+    }
+
+    private void AbandonProbe()
+    {
+        holderProbe.DisconnectFromHost();
+        holderProbe = null;
+    }
+
+    private static bool IsGreeting(byte[] received)
+    {
+        if (received.Length != GreetingBytes.Length)
+            return false;
+        for (int i = 0; i < received.Length; i++)
+        {
+            if (received[i] != GreetingBytes[i])
+                return false;
+        }
+        return true;
     }
 }

--- a/addons/Nebula/Tools/MainScreen/NebulaPerformanceView.cs
+++ b/addons/Nebula/Tools/MainScreen/NebulaPerformanceView.cs
@@ -147,8 +147,7 @@ public partial class NebulaPerformanceView : Control
         placeholder = new Label
         {
             Name = PlaceholderName,
-            Text = "No metrics — the server reports only when NEBULA_PERFORMANCE is set"
-                + " (environment variable or .env entry). Independent of NEBULA_DEBUG.",
+            Text = "Enable NEBULA_PERFORMANCE=true in your .env and run your game.\n",
             HorizontalAlignment = HorizontalAlignment.Center,
             VerticalAlignment = VerticalAlignment.Center,
         };

--- a/addons/Nebula/Tools/MainScreen/nebula_play_orchestrator.gd
+++ b/addons/Nebula/Tools/MainScreen/nebula_play_orchestrator.gd
@@ -34,6 +34,13 @@ var _log_lines: PackedStringArray = PackedStringArray()
 ## can reconnect to a live session after a .NET assembly reload recreates it.
 var _debug_ports: PackedInt32Array = PackedInt32Array()
 var _was_running := false
+## True from the moment a launch begins until stop(), or until every instance has
+## exited. Broader than is_running(), which only knows about spawned pids:
+## play_custom_scene runs the C# build first, so there is a window - seconds, on a
+## cold build - where the session is unmistakably a Nebula one and no instance
+## exists yet. The toolbar hides Godot's run bar on this rather than on
+## is_running(), so the built-in buttons don't flash back during a launch.
+var _active := false
 
 
 ## Entry point for the C# tab. Deferred so the caller's C# frame is off the
@@ -47,6 +54,12 @@ func _do_launch(dummy_scene: String, exe: String, server_args: PackedStringArray
 	if is_running():
 		_log("[play] instances already running — stop them first")
 		return
+
+	# Set before play_custom_scene: that call runs the C# build and any pending
+	# assembly reload, so the toolbar may repaint several times before the first
+	# instance pid exists.
+	_active = true
+	state_changed.emit()
 
 	if not EditorInterface.is_playing_scene():
 		EditorInterface.play_custom_scene(dummy_scene)
@@ -84,9 +97,13 @@ func _do_launch(dummy_scene: String, exe: String, server_args: PackedStringArray
 	_config_name = config_name
 	_debug_ports = debug_ports
 	_was_running = is_running()
+	# A launch that spawned nothing is not an active session; leaving _active set
+	# would hide the built-in run bar with no Nebula session to stop.
+	_active = _was_running
 	state_changed.emit()
 
 func stop() -> void:
+	_active = false
 	_launch_generation += 1
 	for pid in _pids:
 		var err := OS.kill(pid)
@@ -115,12 +132,16 @@ func _process(_delta: float) -> void:
 	var running := is_running()
 	if running == _was_running:
 		return
-	_was_running = running
 	if not running:
-		_pids.clear()
-		_config_name = ""
-		_debug_ports = PackedInt32Array()
+		# Tear the whole session down, not just the pid bookkeeping: the dummy
+		# editor play only exists to serve those instances, and left running it
+		# holds the debug server open with no visible owner - and the toolbar
+		# reads a Nebula dummy session with no Nebula session behind it as a
+		# plain editor play, and hides the Nebula button.
 		_log("[play] all instances exited")
+		stop()
+		return
+	_was_running = running
 	state_changed.emit()
 
 
@@ -129,6 +150,12 @@ func is_running() -> bool:
 		if OS.is_process_running(pid):
 			return true
 	return false
+
+
+## Whether a Nebula session is live in the broad sense - launching, running, or
+## staggering its instances. See _active.
+func is_active() -> bool:
+	return _active
 
 
 func get_config_name() -> String:

--- a/addons/Nebula/Tools/ProjectSettingsController.cs
+++ b/addons/Nebula/Tools/ProjectSettingsController.cs
@@ -46,6 +46,13 @@ public partial class ProjectSettingsController : Node
         ("Nebula/config/log_tick_payloads",     "Nebula/config/debug/log_tick_payloads"),
         ("Nebula/config/debug_export_interval", "Nebula/config/debug/export_interval"),
         ("Nebula/editor/disable_editor_tooling", "Nebula/config/editor/disable_tooling"),
+        // Narrowed in scope, not just renamed: the switch used to suppress the
+        // whole editor tooling and hide Godot's run bar. It now only suppresses
+        // Nebula's own Play button. Carried across so a project that opted out
+        // still gets no Nebula Play button; the run bar and the debugger tab
+        // come back either way. NOTE: order matters here — this pair consumes
+        // the result of the migration above it.
+        ("Nebula/config/editor/disable_tooling", "Nebula/config/editor/disable_play_button"),
     };
 
     /// <summary>
@@ -54,7 +61,7 @@ public partial class ProjectSettingsController : Node
     /// </summary>
     private static readonly string[] ObsoleteSettings =
     {
-        // Superseded by the editor/disable_tooling master switch.
+        // Superseded by the editor/disable_play_button switch.
         "Nebula/editor/hide_embedded_play_buttons",
         // Never read by anything; the live key is config/world/default_scene,
         // which falls back to application/run/main_scene.
@@ -156,11 +163,13 @@ public partial class ProjectSettingsController : Node
         });
 
         // ── Debug ────────────────────────────────────────────────────────
-        // Master switch for the debug channel. On by default, but it never opens a
-        // port on its own: it is ANDed with --debugPort=N, which the editor's Play
-        // button supplies. Turning it off makes NetRunner/WorldRunner skip the
-        // broadcast path entirely rather than merely muting it.
-        Register(NetRunner.DEBUG_SERVER_SETTING, true, new(){
+        // Master switch for the debug channel. OFF by default: a diagnostic channel
+        // has to be asked for, either here or with NEBULA_DEBUG=1 in the process's
+        // .env. Even on it never opens a port by itself - it is ANDed with
+        // --debugPort=N, which the editor's Play button supplies. Off makes
+        // NetRunner/WorldRunner skip the broadcast path entirely rather than merely
+        // muting it.
+        Register(NetRunner.DEBUG_SERVER_SETTING, false, new(){
             {"type", (int)Variant.Type.Bool},
         });
 
@@ -267,10 +276,11 @@ public partial class ProjectSettingsController : Node
         });
 
         // ── Editor ───────────────────────────────────────────────────────
-        // Editor: master switch for the Nebula editor tooling (main-screen tab,
-        // play target button, run-bar hiding, headless run-instances config).
-        // Requires an editor restart to take full effect.
-        Register(Main.DISABLE_TOOLING_SETTING, false, new(){
+        // Editor: suppress Nebula's toolbar Play button and its configuration
+        // dropdown. Godot's own run bar is always left alone, and the debugger
+        // tab, dock and inspector plugin load regardless. Requires an editor
+        // restart to take effect.
+        Register(Main.DISABLE_PLAY_BUTTON_SETTING, false, new(){
             {"type", (int)Variant.Type.Bool},
         });
 

--- a/addons/Nebula/Utils/Env/Env.cs
+++ b/addons/Nebula/Utils/Env/Env.cs
@@ -104,13 +104,20 @@ namespace Nebula.Utility.Tools
 
         /// <summary>
         /// Reads a boolean switch from the process environment, falling back to this
-        /// process's .env file (<c>.env.server</c> or <c>.env.client</c>). <c>"0"</c> and
-        /// <c>"false"</c> mean off; any other non-empty value means on.
+        /// process's .env file (<c>.env.server</c> or <c>.env.client</c>). Only <c>"1"</c>
+        /// and <c>"true"</c> mean on. Every other value means OFF — including ones that
+        /// read as affirmative to a human (<c>"yes"</c>, <c>"on"</c>, <c>"enabled"</c>).
+        /// These switches all gate diagnostics, so an unrecognised value resolving to off
+        /// costs a run its telemetry, whereas the opposite silently leaves instrumentation
+        /// on in a build that asked for none.
         /// </summary>
         /// <returns>
         /// False when the variable is absent everywhere, leaving <paramref name="value"/>
         /// untouched — callers use that to fall back to a project setting rather than
-        /// treating "unset" as "off".
+        /// treating "unset" as "off". A variable that IS present reports true whatever its
+        /// value: writing it at all is a decision to configure the switch, so falling back
+        /// to a project setting that says the opposite would be worse than reading an
+        /// unrecognised value as off.
         /// </returns>
         public static bool TryGetFlag(string name, out bool value)
         {
@@ -125,7 +132,7 @@ namespace Nebula.Utility.Tools
             if (string.IsNullOrEmpty(raw))
                 return false;
 
-            value = raw != "0" && !raw.Equals("false", StringComparison.OrdinalIgnoreCase);
+            value = raw == "1" || raw.Equals("true", StringComparison.OrdinalIgnoreCase);
             return true;
         }
 

--- a/addons/Nebula/plugin.cfg
+++ b/addons/Nebula/plugin.cfg
@@ -3,5 +3,5 @@
 name="Nebula"
 description="Netcode Framework for Online Multiplayer Games"
 author="Heavenlode"
-version="1.9.0"
+version="1.9.1"
 script="Tools/Main.cs"


### PR DESCRIPTION
- Separate ServerMetrics collection from console output: --metrics enables both, NEBULA_PERFORMANCE enables collection and the debug-channel copy only.
- Make Env.TryGetFlag accept only "1" and "true" as on; every other value is off.
- Default Nebula/config/debug/enable_tcp to off so the debug channel has to be asked for, and set NEBULA_DEBUG=1 for processes the integration harness starts.
- Rename editor/disable_tooling to editor/disable_play_button and narrow it to the Play button alone; the tab, dock and inspector plugin always load.
- Attach the Nebula play bar next to Godot's run bar, and hide the run bar only for the duration of a Nebula session instead of on a setting.
- Bump plugin version to 1.9.1 and document the metrics switches.