### PR TITLE
Optimize ack logic

### DIFF
--- a/addons/Nebula/Core/Collections/NetArray.cs
+++ b/addons/Nebula/Core/Collections/NetArray.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Godot;
 
 namespace Nebula.Serialization
@@ -1633,7 +1634,10 @@ namespace Nebula.Serialization
         public static void OnPeerAcknowledge(NetArray<T> obj, UUID peerId, Tick tick)
         {
             if (obj == null || obj._peerState == null) return;
-            if (!obj._peerState.TryGetValue(peerId, out var state)) return;
+            // In place: one hash, no struct copy, no write-back. This runs per array per peer
+            // per ack, which is the hottest per-node path the ack drain has.
+            ref var state = ref CollectionsMarshal.GetValueRefOrNullRef(obj._peerState, peerId);
+            if (Unsafe.IsNullRef(ref state)) return;
 
             // Commit pending chunk progress, but only if this ack covers the chunk send
             if (state.HasPendingChunk && state.ChunkSentTick >= 0 && tick >= state.ChunkSentTick)
@@ -1659,9 +1663,6 @@ namespace Nebula.Serialization
                 Array.Clear(state.PendingDirty, 0, state.PendingDirty.Length);
                 state.LastSendTick = -1;
             }
-
-            // Write back the modified struct
-            obj._peerState[peerId] = state;
         }
 
         /// <summary>

--- a/addons/Nebula/Core/Diagnostics/TickProfiler.cs
+++ b/addons/Nebula/Core/Diagnostics/TickProfiler.cs
@@ -182,6 +182,12 @@ namespace Nebula.Diagnostics
             PropsMemoSlow,
             /// <summary>Eligible sections that found the memo full. Nonzero = raise MemoCapacity.</summary>
             PropsMemoOverflow,
+            /// <summary>
+            /// Nodes whose serializers were visited by an acknowledgement (PeerAcknowledge drain).
+            /// Per tick this should track "nodes that shipped a section" x peers, not "nodes ever
+            /// sent" x peers - the latter is what the pre-ring pending set cost.
+            /// </summary>
+            AckNodesVisited,
             Count,
         }
 
@@ -190,6 +196,7 @@ namespace Nebula.Diagnostics
             "pk_candidates", "pk_bytes_measured", "pk_deltas_chosen",
             "pk_chosen_age_sum", "pk_measured",
             "memo_hit", "memo_miss", "memo_slow", "memo_overflow",
+            "ack_nodes_visited",
         };
         private const int CounterCount = (int)Counter.Count;
 

--- a/addons/Nebula/Core/NetNode.cs
+++ b/addons/Nebula/Core/NetNode.cs
@@ -56,6 +56,17 @@ namespace Nebula
             Serializers = [spawnSerializer, propertySerializer, interestResyncSerializer];
         }
 
+        /// <summary>
+        /// Test seam: installs hand-built serializers. SetupSerializers needs the Protocol
+        /// registry (a registered net scene), which the Protocol-free unit fixtures don't have;
+        /// this lets a WorldRunner-level test drive PeerAcknowledge against a recording
+        /// serializer and a Protocol-free NetPropertiesSerializer.
+        /// </summary>
+        internal void SetSerializersForTests(IStateSerializer[] serializers)
+        {
+            Serializers = serializers;
+        }
+
         public virtual void _WorldReady() { }
         public virtual void _NetworkProcess(int _tick) { }
         public virtual void _Despawn() { }

--- a/addons/Nebula/Core/Serialization/SentNodeRing.cs
+++ b/addons/Nebula/Core/Serialization/SentNodeRing.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+
+namespace Nebula.Serialization
+{
+    /// <summary>
+    /// Per-peer record of which nodes had a section committed into each recent tick's packet,
+    /// so an acknowledgement for tick T visits exactly the nodes whose bytes rode packet T.
+    ///
+    /// <para>This replaces a per-peer "pending acks" set that every ack walked in full. That
+    /// set only ever grew: a node with object properties never left it, so at 40 peers every
+    /// ack (one per input packet, ~30/s/peer) called <c>Acknowledge</c> on every serializer of
+    /// every node the peer had ever been sent. Every serializer's <c>Acknowledge</c> only acts
+    /// on ticks in which it committed bytes (spawn <c>SendWindow.Covers</c>, props
+    /// <c>SentHistory[T].Tick == T</c>, and object properties only ship inside a committed
+    /// props section), so visiting anything else was pure cost.</para>
+    ///
+    /// <para>Slots are indexed by <c>tick % Depth</c> and stamped with their tick, so a slot
+    /// that has wrapped is never mistaken for the requested one. Lists are cleared and reused,
+    /// never reallocated, so steady state is allocation-free.</para>
+    /// </summary>
+    internal sealed class SentNodeRing
+    {
+        /// <summary>
+        /// How many ticks back an acknowledgement can still be matched to its packet, ~2 s at
+        /// 30 TPS. Nothing else in the system acts on an older ack: the props sent-history is
+        /// 32 deep and <see cref="NebulaPackWindow.MaxPackAge"/> is 30, so 64 is a 2x margin
+        /// over the oldest ack any consumer can use. An ack older than this is ignored, which
+        /// costs one extra resend round for a spawn window or an object property's pending
+        /// set - both resend every tick until acked. The 30 s join window is covered by that
+        /// resend-until-acked rule, not by ack depth, so it does not size this.
+        /// </summary>
+        public const int Depth = 64;
+
+        /// <summary>Stamp meaning "slot never written"; ticks start at 0, so -1 cannot collide.</summary>
+        private const int EmptyStamp = -1;
+
+        private readonly Tick[] _stamps = new Tick[Depth];
+        private readonly List<NetworkController>[] _slots = new List<NetworkController>[Depth];
+
+        public SentNodeRing() => Reset();
+
+        /// <summary>
+        /// Claims the slot for <paramref name="tick"/>: stamps it and empties its list. Called
+        /// once per peer per tick at the start of that peer's export.
+        /// </summary>
+        public void Begin(Tick tick)
+        {
+            int idx = SlotOf(tick);
+            _stamps[idx] = tick;
+            var list = _slots[idx];
+            if (list == null)
+            {
+                _slots[idx] = new List<NetworkController>(64);
+            }
+            else
+            {
+                list.Clear();
+            }
+            _currentIdx = idx;
+        }
+
+        private int _currentIdx = -1;
+
+        /// <summary>Registers a node whose section was committed into the tick begun by <see cref="Begin"/>.</summary>
+        public void Add(NetworkController node)
+        {
+            _slots[_currentIdx].Add(node);
+        }
+
+        /// <summary>
+        /// The nodes committed into the packet for <paramref name="tick"/>, if that tick's slot
+        /// still holds it. False when the tick was never begun here or has since wrapped.
+        /// </summary>
+        public bool TryGet(Tick tick, out List<NetworkController> nodes)
+        {
+            nodes = null;
+            if (tick < 0) return false;
+            int idx = SlotOf(tick);
+            if (_stamps[idx] != tick) return false;
+            nodes = _slots[idx];
+            return nodes != null;
+        }
+
+        /// <summary>Forgets every tick. Lists are kept for reuse.</summary>
+        public void Reset()
+        {
+            for (int i = 0; i < Depth; i++)
+            {
+                _stamps[i] = EmptyStamp;
+                _slots[i]?.Clear();
+            }
+            _currentIdx = -1;
+        }
+
+        private static int SlotOf(Tick tick) => (int)((uint)(int)tick % Depth);
+    }
+}

--- a/addons/Nebula/Core/Serialization/SentNodeRing.cs.uid
+++ b/addons/Nebula/Core/Serialization/SentNodeRing.cs.uid
@@ -1,0 +1,1 @@
+uid://bkuo8636pgfkw

--- a/addons/Nebula/Core/Serialization/Serializers/IStateSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/IStateSerializer.cs
@@ -93,13 +93,16 @@ namespace Nebula.Serialization.Serializers
         /// Server-side only. Called when a peer acknowledges the packet exported at
         /// <paramref name="tick"/>. Implementations must only commit state that was sent
         /// at or before that tick.
+        ///
+        /// Delivery contract: the host only calls this for ticks in which this node had a
+        /// section committed into the peer's packet (or, for a nested scene, rode an
+        /// ancestor's spawn table) - see <c>WorldRunner.PeerAcknowledge</c> and
+        /// <c>SentNodeRing</c>. An implementation must therefore stamp every "sent at T"
+        /// record from <see cref="CommitExport"/> (or from inside a write the host will
+        /// commit), never from a path that produces no bytes: a stamp with no section is a
+        /// stamp no ack can ever reach.
         /// </summary>
-        /// <returns>
-        /// True if this serializer still has unacknowledged data for the peer; false when
-        /// fully acked. When every serializer of a node returns false, the node is removed
-        /// from the per-peer pending-ack set (it re-enters on its next export).
-        /// </returns>
-        public bool Acknowledge(WorldRunner currentWorld, NetPeer peer, Tick tick);
+        public void Acknowledge(WorldRunner currentWorld, NetPeer peer, Tick tick);
 
         public void Cleanup();
         

--- a/addons/Nebula/Core/Serialization/Serializers/InterestResyncSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/InterestResyncSerializer.cs
@@ -25,7 +25,7 @@ namespace Nebula.Serialization.Serializers
         public void Begin() { }
         public void Cleanup() { }
         public void CleanupPeer(UUID peerId) { }
-        public bool Acknowledge(WorldRunner currentWorld, NetPeer peer, Tick latestAck) => false;
+        public void Acknowledge(WorldRunner currentWorld, NetPeer peer, Tick latestAck) { }
 
         public ExportResult Export(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer, int maxBytes)
         {

--- a/addons/Nebula/Core/Serialization/Serializers/NetPropertiesSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/NetPropertiesSerializer.cs
@@ -3052,9 +3052,36 @@ namespace Nebula.Serialization.Serializers
             }
         }
 
-        public bool Acknowledge(WorldRunner currentWorld, NetPeer peer, Tick latestAck)
+        public void Acknowledge(WorldRunner currentWorld, NetPeer peer, Tick latestAck)
         {
             var peerId = NetRunner.Instance.GetPeerId(peer);
+
+            // Zero-alloc ref access. ExportCore creates this state before it writes a single
+            // byte and CommitExport refuses to stamp without it, so "no state" means no
+            // section of this node has ever been committed to this peer: nothing to ack.
+            ref var state = ref CollectionsMarshal.GetValueRefOrNullRef(_peerStates, peerId);
+            if (Unsafe.IsNullRef(ref state) || !state.IsInitialized)
+            {
+                return;
+            }
+
+            // An ack for tick N proves the peer received the packet exported at N, which
+            // contained the tick-N value of every then-pending property. It proves nothing
+            // about sends at later ticks, so only the tick-N record is committed.
+            //
+            // The record gates the OBJECT properties too: their bytes only ever ship inside a
+            // committed props section, and CommitExport stamps this record for every committed
+            // section, object-only ones included (primitiveSentMask == 0). No record means no
+            // section rode tick N, so there is nothing for an array to commit - and skipping
+            // the loop is what makes an ack cost nothing for a node that only shipped a spawn
+            // or resync byte that tick. Consequence for an ack older than the 32-tick history
+            // (slot overwritten): the object loop no longer runs where it used to. Object
+            // properties resend every tick until acked, so the next in-range ack clears them.
+            ref var ackedRecord = ref state.SentHistory[latestAck % SNAPSHOT_RING_SIZE];
+            if (ackedRecord.Tick != latestAck)
+            {
+                return;
+            }
 
             // Call OnPeerAcknowledge on all object properties (they gate on the tick themselves)
             for (int i = 0; i < _propertyCount; i++)
@@ -3077,70 +3104,46 @@ namespace Nebula.Serialization.Serializers
                 }
             }
 
-            // Zero-alloc ref access
-            ref var state = ref CollectionsMarshal.GetValueRefOrNullRef(_peerStates, peerId);
-            if (Unsafe.IsNullRef(ref state) || !state.IsInitialized)
-            {
-                // No primitive state yet; object props were still notified above
-                return _hasObjectProps;
-            }
+            long ackedSent = ackedRecord.SentMask;
 
-            // An ack for tick N proves the peer received the packet exported at N, which
-            // contained the tick-N value of every then-pending property. It proves nothing
-            // about sends at later ticks, so only the tick-N record is committed.
-            ref var ackedRecord = ref state.SentHistory[latestAck % SNAPSHOT_RING_SIZE];
-            if (ackedRecord.Tick == latestAck)
+            if (ackedSent != 0)
             {
-                long ackedSent = ackedRecord.SentMask;
-
-                if (ackedSent != 0)
+                // Mark these props as confirmed-received (enables delta encoding)
+                for (int i = 0; i < state.AckedMask.Length; i++)
                 {
-                    // Mark these props as confirmed-received (enables delta encoding)
-                    for (int i = 0; i < state.AckedMask.Length; i++)
-                    {
-                        int shift = i * 8;
-                        if (shift >= 64) break;
-                        state.AckedMask[i] |= (byte)((ackedSent >> shift) & 0xFF);
-                    }
+                    int shift = i * 8;
+                    if (shift >= 64) break;
+                    state.AckedMask[i] |= (byte)((ackedSent >> shift) & 0xFF);
+                }
 
-                    // Stop resending only props whose value did NOT change again after the
-                    // acked tick - a later DIRTY send carries a newer value the client may not
-                    // have yet. A later RESEND of the same value does not (see DirtySentMask).
-                    long laterSent = 0;
-                    for (int i = 0; i < state.SentHistory.Length; i++)
+                // Stop resending only props whose value did NOT change again after the
+                // acked tick - a later DIRTY send carries a newer value the client may not
+                // have yet. A later RESEND of the same value does not (see DirtySentMask).
+                long laterSent = 0;
+                for (int i = 0; i < state.SentHistory.Length; i++)
+                {
+                    if (state.SentHistory[i].Tick > latestAck)
                     {
-                        if (state.SentHistory[i].Tick > latestAck)
-                        {
-                            laterSent |= state.SentHistory[i].DirtySentMask;
-                        }
-                    }
-
-                    long clearMask = ackedSent & ~laterSent;
-                    for (int i = 0; i < state.PendingDirtyMask.Length; i++)
-                    {
-                        int shift = i * 8;
-                        if (shift >= 64) break;
-                        state.PendingDirtyMask[i] &= (byte)~((clearMask >> shift) & 0xFF);
+                        laterSent |= state.SentHistory[i].DirtySentMask;
                     }
                 }
 
-                // The baseline must be a tick at which THIS node's data was received, so
-                // the client is guaranteed to have a matching applied-state ring entry.
-                // Only advance on ticks with a SentHistory record (node exported that tick).
-                if (latestAck > state.LatestAckedTick)
+                long clearMask = ackedSent & ~laterSent;
+                for (int i = 0; i < state.PendingDirtyMask.Length; i++)
                 {
-                    state.LatestAckedTick = latestAck;
+                    int shift = i * 8;
+                    if (shift >= 64) break;
+                    state.PendingDirtyMask[i] &= (byte)~((clearMask >> shift) & 0xFF);
                 }
             }
 
-            // Still pending if any primitive props await an ack (object props conservatively
-            // keep the node in the pending set; re-adding on next export is cheap)
-            if (_hasObjectProps) return true;
-            for (int i = 0; i < state.PendingDirtyMask.Length; i++)
+            // The baseline must be a tick at which THIS node's data was received, so
+            // the client is guaranteed to have a matching applied-state ring entry.
+            // Only advance on ticks with a SentHistory record (node exported that tick).
+            if (latestAck > state.LatestAckedTick)
             {
-                if (state.PendingDirtyMask[i] != 0) return true;
+                state.LatestAckedTick = latestAck;
             }
-            return false;
         }
 
     }

--- a/addons/Nebula/Core/Serialization/Serializers/SpawnSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/SpawnSerializer.cs
@@ -265,6 +265,13 @@ namespace Nebula.Serialization.Serializers
                             nestedSpawnSerializer.spawnWindows.TryGetValue(peerId, out var nestedWindow);
                             nestedWindow.RecordSend(tick);
                             nestedSpawnSerializer.spawnWindows[peerId] = nestedWindow;
+
+                            // The child committed no section of its own, so the host would
+                            // never route this tick's ack to it - and the window just
+                            // stamped would be unreachable. Register it as a rider of this
+                            // packet. (Before the per-tick ack ring, a child with nothing
+                            // else to send could sit in Spawning until it happened to export.)
+                            currentWorld.NoteNestedSpawnRider(nested);
                         }
                     }
                     break;
@@ -704,7 +711,7 @@ namespace Nebula.Serialization.Serializers
             }
         }
 
-        public bool Acknowledge(WorldRunner currentWorld, NetPeer peer, Tick tick)
+        public void Acknowledge(WorldRunner currentWorld, NetPeer peer, Tick tick)
         {
             var peerId = NetRunner.Instance.GetPeerId(peer);
 
@@ -745,7 +752,7 @@ namespace Nebula.Serialization.Serializers
                 }
                 // If the despawn is still unacked, don't process spawn ACK
                 // The node is being despawned, so transitioning to Spawned would be wrong
-                return despawnWindows.ContainsKey(peerId) || spawnWindows.ContainsKey(peerId);
+                return;
             }
 
             // Handle spawn acknowledgment (only if no despawn is pending).
@@ -765,9 +772,6 @@ namespace Nebula.Serialization.Serializers
                     spawnWindows.Remove(peerId); // Clean up after successful ack
                 }
             }
-
-            // Still pending while an unacked spawn or despawn send exists for this peer
-            return spawnWindows.ContainsKey(peerId) || despawnWindows.ContainsKey(peerId);
         }
 
         // Import is client-only and infrequent, less critical to optimize

--- a/addons/Nebula/Core/WorldRunner.cs
+++ b/addons/Nebula/Core/WorldRunner.cs
@@ -1640,7 +1640,7 @@ namespace Nebula
             _peerLastAckTick.Remove(peerId);
             ResetPackState(peerId);
             _peerPackWindows.Remove(peerId);
-            _peerPendingAcks.Remove(peerId); // Fix #5: Clean up pending acks tracking
+            _peerSentRings.Remove(peerId); // Per-tick ack routing
             _peerNetBufferPool.Remove(peerId); // Clean up pooled export buffer
             _peerPropsCursors.Remove(peerId); // Round-robin cursor for the props phase
             _peerListDirty = true; // Fix #1: Mark peer list as dirty
@@ -2903,10 +2903,30 @@ namespace Nebula
         private bool _peerListDirty = true;
 
         /// <summary>
-        /// Tracks which network objects have pending unacked data per peer (Fix #5).
-        /// This allows PeerAcknowledge to only iterate relevant objects instead of all NetScenes.
+        /// Per peer: which nodes had a section committed into each recent tick's packet, so an
+        /// ack for tick T visits exactly those nodes (see <see cref="SentNodeRing"/>). Created
+        /// lazily inside ExportState on the world thread - never from JoinPeer, which runs on
+        /// main while this world may be mid-export - and dropped with the rest of the per-peer
+        /// state in TeardownPeer/ExitPeer.
         /// </summary>
-        private Dictionary<UUID, HashSet<NetworkController>> _peerPendingAcks = new();
+        private readonly Dictionary<UUID, SentNodeRing> _peerSentRings = new();
+
+        /// <summary>
+        /// Controller behind each peer-local node id that has a section in the packet being
+        /// assembled. Written by TryAppendSection on a node's first section; only ever read
+        /// behind a set bit of <c>_updatedNodesMask</c>, so entries left over from an earlier
+        /// peer are never observed.
+        /// </summary>
+        private readonly NetworkController[] _peerNodesControllers = new NetworkController[NodeIdUtils.MAX_NETWORK_NODES];
+
+        /// <summary>
+        /// Nested scenes that rode an ancestor's spawn table in the packet being assembled
+        /// without committing a section of their own (SpawnSerializer.CommitExport reports
+        /// them via <see cref="NoteNestedSpawnRider"/>). Registered into the ack ring after
+        /// the mask walk, minus any that also committed a section. Cleared per peer.
+        /// </summary>
+        private readonly List<NetworkController> _tickNestedRiders = new(16);
+        private readonly long[] _tickRiderMask = NodeIdUtils.CreateMasks();
 
         /// <summary>
         /// Buffer for tick-aligned player joined events.
@@ -3169,9 +3189,9 @@ namespace Nebula
             // Fix #1: Mark peer list as dirty so it gets rebuilt
             _peerListDirty = true;
 
-            // Fix #5: Initialize pending acks tracking for this peer
-            _peerPendingAcks[peerId] = new HashSet<NetworkController>();
-            
+            // Deliberately no per-peer export state here (ack ring, buffer pool, cursors): this
+            // runs on main, ExportState owns those on the world thread and creates them lazily.
+
             // Initialize interest layers for the root scene immediately so properties
             // can be exported on the same tick as the spawn
             if (RootScene != null)
@@ -3185,6 +3205,12 @@ namespace Nebula
             var peerId = NetRunner.Instance.GetPeerId(peer);
             NetRunner.Instance.PeerWorldMap.Remove(peerId);
             PeerStates.Remove(peerId);
+            // Per-peer export state, same set TeardownPeer drops. These used to leak here.
+            _peerSentRings.Remove(peerId);
+            _peerNetBufferPool.Remove(peerId);
+            _peerPropsCursors.Remove(peerId);
+            _peerPackWindows.Remove(peerId);
+            _peerListDirty = true;
         }
 
         /// <summary>
@@ -3325,12 +3351,17 @@ namespace Nebula
                 // properties are load-bearing rather than tidy.
                 ExportPartition.Partition(_tickNodeList, peer, _tickOwnedList, _tickSharedList);
 
-                // Fix #5: Get or create pending acks set for this peer
-                if (!_peerPendingAcks.TryGetValue(peerId, out var pendingAcks))
+                // Ack routing for this packet: every node that commits a section below is
+                // registered into this tick's slot after the phases run (mask walk at the
+                // end of the loop), so the ack for CurrentTick visits exactly those nodes.
+                if (!_peerSentRings.TryGetValue(peerId, out var sentRing))
                 {
-                    pendingAcks = new HashSet<NetworkController>();
-                    _peerPendingAcks[peerId] = pendingAcks;
+                    sentRing = new SentNodeRing();
+                    _peerSentRings[peerId] = sentRing;
                 }
+                sentRing.Begin(CurrentTick);
+                _tickNestedRiders.Clear();
+                Array.Clear(_tickRiderMask, 0, NodeIdUtils.NODE_GROUPS);
 
                 var ledger = new TickBudgetLedger(payloadBudget);
                 var peerState = PeerStates[peerId];
@@ -3395,7 +3426,7 @@ namespace Nebula
                             continue;
                         }
 
-                        if (!TryAppendSection(localNodeId, SpawnSerializerIndex, ref ledger))
+                        if (!TryAppendSection(netController, localNodeId, SpawnSerializerIndex, ref ledger))
                         {
                             // Over budget: retries next tick. Should only ever be transient
                             // (a crowded packet) - a record too big for an EMPTY packet can
@@ -3411,7 +3442,6 @@ namespace Nebula
                             if (spawnPass == 0) ownedSpawnSectionsDeferred++; else spawnSectionsDeferred++;
                             continue;
                         }
-                        pendingAcks.Add(netController);
                         serializer.CommitExport(this, peer, CurrentTick);
                     }
                 }
@@ -3481,13 +3511,12 @@ namespace Nebula
                         continue;
                     }
 
-                    if (!TryAppendSection(ownedLocalId, PropsSerializerIndex, ref ledger))
+                    if (!TryAppendSection(netController, ownedLocalId, PropsSerializerIndex, ref ledger))
                     {
                         Log(Debugger.DebugLevel.ERROR,
                             $"[ExportState] BUG: owned props section for {netController.RawNode?.Name} (NetId={netController.NetId}) exceeded its budget and was dropped.");
                         continue;
                     }
-                    pendingAcks.Add(netController);
                     serializer.CommitExport(this, peer, CurrentTick);
                 }
 
@@ -3551,7 +3580,7 @@ namespace Nebula
                             continue;
                         }
 
-                        if (!TryAppendSection(localNodeId, PropsSerializerIndex, ref ledger))
+                        if (!TryAppendSection(netController, localNodeId, PropsSerializerIndex, ref ledger))
                         {
                             // Contract breach: a self-limiting serializer wrote past its
                             // section budget. The bytes are dropped and never committed,
@@ -3561,7 +3590,6 @@ namespace Nebula
                                 $"[ExportState] BUG: props section for {netController.RawNode?.Name} (NetId={netController.NetId}) exceeded its budget and was dropped.");
                             continue;
                         }
-                        pendingAcks.Add(netController);
                         serializer.CommitExport(this, peer, CurrentTick);
 
                         if (result == ExportResult.Partial && !cursorPinned)
@@ -3607,11 +3635,10 @@ namespace Nebula
                     {
                         continue;
                     }
-                    if (!TryAppendSection(localNodeId, InterestResyncSerializerIndex, ref ledger))
+                    if (!TryAppendSection(netController, localNodeId, InterestResyncSerializerIndex, ref ledger))
                     {
                         continue; // dropped: the next stagger slot resyncs, no ack state
                     }
-                    pendingAcks.Add(netController);
                     serializer.CommitExport(this, peer, CurrentTick);
                 }
 
@@ -3653,6 +3680,11 @@ namespace Nebula
                         var serializersRun = _peerNodesSerializersList[nodeId];
                         NetWriter.WriteByte(_exportPeerBuffers[peerId], serializersRun);
 
+                        // This mask is, by construction, the deduplicated set of nodes with
+                        // a committed section in this packet - so it is also the exact set
+                        // the ack for CurrentTick must visit.
+                        sentRing.Add(_peerNodesControllers[nodeId]);
+
                         // Spawn-contract breach detector: a packet may carry data WITHOUT
                         // the spawn bit only for a node whose id the client provably has
                         // or gets - spawn committed (Spawned), or riding an in-flight
@@ -3688,6 +3720,22 @@ namespace Nebula
                         }
                     }
                 }
+                // Nested scenes that rode an ancestor's spawn table this packet had their
+                // spawn windows stamped for CurrentTick without a section of their own, so
+                // the mask walk above cannot see them. Register the ones it did not: a
+                // rider that ALSO committed its own section (its props phase ran after the
+                // parent's spawn commit) is already in the ring. Must run after the mask
+                // walk so the dedup reads the final mask.
+                for (int r = 0; r < _tickNestedRiders.Count; r++)
+                {
+                    var rider = _tickNestedRiders[r];
+                    if (!peerState.WorldToPeerNodeMap.TryGetValue(rider.NetId, out var riderLocalId)) continue;
+                    if (NodeIdUtils.IsBitSet(_updatedNodesMask, riderLocalId)) continue;
+                    if (NodeIdUtils.IsBitSet(_tickRiderMask, riderLocalId)) continue;
+                    NodeIdUtils.SetBit(_tickRiderMask, riderLocalId);
+                    sentRing.Add(rider);
+                }
+
                 for (int g = 0; g < NodeIdUtils.NODE_GROUPS; g++)
                 {
                     if ((groupMask & (1 << g)) == 0) continue;
@@ -3741,7 +3789,7 @@ namespace Nebula
         /// </summary>
         private static readonly bool TraceWire = System.Environment.GetEnvironmentVariable("NEBULA_TRACE_WIRE") != null;
         private UUID _traceWirePeer;
-        private bool TryAppendSection(ushort localNodeId, int serializerIdx, ref TickBudgetLedger ledger)
+        private bool TryAppendSection(NetworkController netController, ushort localNodeId, int serializerIdx, ref TickBudgetLedger ledger)
         {
             if (TraceWire)
             {
@@ -3758,6 +3806,7 @@ namespace Nebula
             if (firstSection)
             {
                 NodeIdUtils.SetBit(_updatedNodesMask, localNodeId);
+                _peerNodesControllers[localNodeId] = netController;
                 if (!_nodeBufferPool.TryGetValue(localNodeId, out var nodeBuffer))
                 {
                     nodeBuffer = new NetBuffer();
@@ -4026,8 +4075,35 @@ namespace Nebula
             }
         }
 
-        // Reusable list for objects that had all data acked (avoids modifying HashSet during iteration)
-        private List<NetworkController> _ackedObjects = new(64);
+        /// <summary>
+        /// Called by SpawnSerializer.CommitExport, mid-peer and mid-tick on the world thread,
+        /// for a nested scene whose spawn window it just stamped because the child rode this
+        /// packet inside an ancestor's spawn table. ExportState folds these into the tick's
+        /// ack routing after its phases run (see the rider block at the end of the peer loop).
+        /// </summary>
+        internal void NoteNestedSpawnRider(NetworkController child)
+        {
+            _tickNestedRiders.Add(child);
+        }
+
+        /// <summary>
+        /// Test seam: registers <paramref name="node"/> as having shipped in the packet for
+        /// <paramref name="tick"/> to <paramref name="peerId"/>, exactly as ExportState's mask
+        /// walk would, so PeerAcknowledge can be driven without a Protocol registry.
+        /// </summary>
+        internal void RegisterSentNodeForTests(UUID peerId, Tick tick, NetworkController node)
+        {
+            if (!_peerSentRings.TryGetValue(peerId, out var ring))
+            {
+                ring = new SentNodeRing();
+                _peerSentRings[peerId] = ring;
+            }
+            if (!ring.TryGet(tick, out _))
+            {
+                ring.Begin(tick);
+            }
+            ring.Add(node);
+        }
 
         public void PeerAcknowledge(NetPeer peer, Tick tick)
         {
@@ -4072,40 +4148,32 @@ namespace Nebula
                 SetPeerState(peerId, newPeerState);
             }
 
-            // Fix #5: Only iterate objects that have pending data for this peer
-            if (!_peerPendingAcks.TryGetValue(peerId, out var pendingAcks) || pendingAcks.Count == 0)
+            // Route the ack to exactly the nodes whose bytes rode packet `tick`. Every
+            // serializer's Acknowledge only acts on ticks it committed in (spawn windows,
+            // props sent-history, object props inside a committed props section), so nothing
+            // else can have anything to do with this ack. An ack older than the ring's depth
+            // finds no slot and is dropped; every consumer resends until acked, so that
+            // costs one extra round (see SentNodeRing.Depth).
+            if (!_peerSentRings.TryGetValue(peerId, out var sentRing) || !sentRing.TryGet(tick, out var sentNodes))
             {
                 return;
             }
 
-            _ackedObjects.Clear();
-            foreach (var netController in pendingAcks)
+            for (var n = 0; n < sentNodes.Count; n++)
             {
-                if (netController == null || netController.NetNode?.Serializers == null)
+                var netController = sentNodes[n];
+                // A node can be freed between commit and ack (despawn completed, peer left).
+                if (netController == null || netController.IsMarkedForDeletion || netController.NetNode?.Serializers == null)
                 {
-                    _ackedObjects.Add(netController); // Remove invalid entries
                     continue;
                 }
 
-                bool stillPending = false;
-                for (var serializerIdx = 0; serializerIdx < netController.NetNode.Serializers.Length; serializerIdx++)
+                _profiler?.Add(Diagnostics.TickProfiler.Counter.AckNodesVisited, 1);
+                var serializers = netController.NetNode.Serializers;
+                for (var serializerIdx = 0; serializerIdx < serializers.Length; serializerIdx++)
                 {
-                    var serializer = netController.NetNode.Serializers[serializerIdx];
-                    stillPending |= serializer.Acknowledge(this, peer, tick);
+                    serializers[serializerIdx].Acknowledge(this, peer, tick);
                 }
-
-                // Fully acked - remove from the pending set so future acks skip this node.
-                // It re-enters via pendingAcks.Add() the next time it exports data.
-                if (!stillPending)
-                {
-                    _ackedObjects.Add(netController);
-                }
-            }
-
-            // Remove invalid and fully-acked entries
-            foreach (var obj in _ackedObjects)
-            {
-                pendingAcks.Remove(obj);
             }
         }
 

--- a/addons/Nebula/Testing/Unit/PeerAckRingTests.cs
+++ b/addons/Nebula/Testing/Unit/PeerAckRingTests.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using Godot;
+using Nebula;
+using Nebula.Serialization;
+using Nebula.Serialization.Serializers;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// WorldRunner.PeerAcknowledge routes an ack for tick T to exactly the nodes registered as
+/// having shipped in packet T - not to every node the peer was ever sent. Driven through the
+/// RegisterSentNodeForTests seam (what ExportState's mask walk does) and a recording
+/// serializer installed via SetSerializersForTests, since neither ExportState nor
+/// SetupSerializers can run without the Protocol registry.
+///
+/// Ack ordering in these tests is deliberate: PeerAcknowledge remembers the FIRST acked tick
+/// and drops any ack at or below it, so a "miss" ack must be issued before a "hit" one at a
+/// higher tick, never after.
+/// </summary>
+[NebulaUnitTest]
+public class PeerAckRingTests
+{
+    /// <summary>Counts Acknowledge calls and remembers the ticks they came with.</summary>
+    private sealed class RecordingSerializer : IStateSerializer
+    {
+        public readonly List<int> AckedTicks = new();
+        public void Begin() { }
+        public bool Import(WorldRunner currentWorld, NetBuffer data, out NetworkController nodeOut)
+        {
+            nodeOut = null;
+            return true;
+        }
+        public ExportResult Export(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer, int maxBytes) => ExportResult.None;
+        public void Acknowledge(WorldRunner currentWorld, NetPeer peer, Tick tick) => AckedTicks.Add(tick);
+        public void Cleanup() { }
+    }
+
+    private sealed class Fixture : IDisposable
+    {
+        public WorldRunner World;
+        public NetPeer Peer;      // default(NetPeer): ID 0, mapped in PeerIds below
+        public UUID PeerId;
+        public readonly List<NetNode> Nodes = new();
+
+        public Fixture()
+        {
+            World = new WorldRunner();
+            Peer = default;
+            PeerId = UUID.NewUUID();
+            NetRunner.Instance.PeerIds[0] = PeerId;
+            World.CreatePeerStateForTests(Peer, PeerId);
+        }
+
+        /// <summary>A node whose only serializer records the acks it receives.</summary>
+        public (NetNode node, RecordingSerializer recorder) RecordingNode()
+        {
+            var node = new NetNode();
+            node.Network.CurrentWorld = World;
+            var recorder = new RecordingSerializer();
+            node.SetSerializersForTests([recorder]);
+            Nodes.Add(node);
+            return (node, recorder);
+        }
+
+        public void Dispose()
+        {
+            NetRunner.Instance.PeerIds.Remove(0);
+            foreach (var node in Nodes)
+            {
+                // Free explicitly even if a test queued the node for deletion: the queued
+                // free only runs at a frame boundary, and the deferred entry is harmless
+                // once the object is already gone (SceneTree skips freed ids).
+                if (GodotObject.IsInstanceValid(node))
+                {
+                    node.Free();
+                }
+            }
+            World.Free();
+        }
+    }
+
+    // 1. The whole point: an ack visits the nodes registered for THAT tick and nothing else.
+    [NebulaUnitTest]
+    public void Ack_VisitsOnlyNodesRegisteredForThatTick()
+    {
+        using var f = new Fixture();
+        var (shipped, shippedRec) = f.RecordingNode();
+        var (idle, idleRec) = f.RecordingNode();
+        f.World.CurrentTick = 10;
+
+        f.World.RegisterSentNodeForTests(f.PeerId, 5, shipped.Network);
+        // `idle` shipped on a different tick only.
+        f.World.RegisterSentNodeForTests(f.PeerId, 7, idle.Network);
+
+        // Tick 4: nothing shipped. Issued first so the first-ack guard doesn't mask tick 5.
+        f.World.PeerAcknowledge(f.Peer, 4);
+        Assert.Empty(shippedRec.AckedTicks);
+        Assert.Empty(idleRec.AckedTicks);
+
+        f.World.PeerAcknowledge(f.Peer, 5);
+        Assert.Equal(new[] { 5 }, shippedRec.AckedTicks);
+        Assert.Empty(idleRec.AckedTicks);
+
+        f.World.PeerAcknowledge(f.Peer, 7);
+        Assert.Equal(new[] { 5 }, shippedRec.AckedTicks);
+        Assert.Equal(new[] { 7 }, idleRec.AckedTicks);
+    }
+
+    // 2. Ring depth: an ack whose slot has been reused by a later tick is dropped (the
+    //    consumer resends until acked, so this costs one round); the newer tick still lands.
+    [NebulaUnitTest]
+    public void Ack_OlderThanRingDepth_IsIgnored_NewerStillLands()
+    {
+        using var f = new Fixture();
+        var (old, oldRec) = f.RecordingNode();
+        var (recent, recentRec) = f.RecordingNode();
+        int oldTick = 5;
+        int wrapTick = oldTick + SentNodeRing.Depth;
+        f.World.CurrentTick = wrapTick + 1;
+
+        f.World.RegisterSentNodeForTests(f.PeerId, oldTick, old.Network);
+        f.World.RegisterSentNodeForTests(f.PeerId, wrapTick, recent.Network); // same slot
+
+        f.World.PeerAcknowledge(f.Peer, oldTick);
+        Assert.Empty(oldRec.AckedTicks);
+        Assert.Empty(recentRec.AckedTicks);
+
+        f.World.PeerAcknowledge(f.Peer, wrapTick);
+        Assert.Empty(oldRec.AckedTicks);
+        Assert.Equal(new[] { wrapTick }, recentRec.AckedTicks);
+    }
+
+    // 3. A node freed between commit and ack is skipped, not acked into a dead serializer.
+    [NebulaUnitTest]
+    public void Ack_SkipsNodeMarkedForDeletion()
+    {
+        using var f = new Fixture();
+        var (doomed, doomedRec) = f.RecordingNode();
+        var (alive, aliveRec) = f.RecordingNode();
+        f.World.CurrentTick = 10;
+
+        f.World.RegisterSentNodeForTests(f.PeerId, 5, doomed.Network);
+        f.World.RegisterSentNodeForTests(f.PeerId, 5, alive.Network);
+        doomed.Network.QueueNodeForDeletion();
+
+        f.World.PeerAcknowledge(f.Peer, 5);
+
+        Assert.Empty(doomedRec.AckedTicks);
+        Assert.Equal(new[] { 5 }, aliveRec.AckedTicks);
+    }
+
+    // 4. End to end with the real props serializer: a committed section's pending bits clear
+    //    on the ack for its tick when the node is routed through the ring.
+    [NebulaUnitTest]
+    public void Ack_ThroughRing_ClearsPropsPendingBits()
+    {
+        using var f = new Fixture();
+        var node = new NetNode();
+        f.Nodes.Add(node);
+        node.Network.CurrentWorld = f.World;
+        node.Network.InterestLayers[f.PeerId] = 1;
+        var propTypes = new[] { SerialVariantType.Int, SerialVariantType.Int };
+        for (var i = 0; i < propTypes.Length; i++)
+        {
+            node.Network.CachedProperties[i] = new PropertyCache { Type = propTypes[i], IntValue = 40 + i };
+        }
+        var props = new NetPropertiesSerializer(node.Network, propTypes);
+        var recorder = new RecordingSerializer();
+        node.SetSerializersForTests([recorder, props]);
+        f.World.SetClientSpawnState(node.Network.NetId, f.Peer, WorldRunner.ClientSpawnState.Spawning);
+
+        f.World.CurrentTick = 5;
+        node.Network.DirtyMask = 0b11;
+        props.Begin();
+        var buf = new NetBuffer(512, usePool: false);
+        Assert.Equal(ExportResult.Written, props.Export(f.World, f.Peer, buf, int.MaxValue));
+        props.CommitExport(f.World, f.Peer, 5);
+        f.World.RegisterSentNodeForTests(f.PeerId, 5, node.Network);
+        Assert.Equal(0b11, props.PendingDirtyByteForTests(f.PeerId, 0));
+
+        f.World.PeerAcknowledge(f.Peer, 5);
+
+        Assert.Equal(0, props.PendingDirtyByteForTests(f.PeerId, 0));
+        Assert.Equal(new[] { 5 }, recorder.AckedTicks);
+    }
+
+    // 5. Acks for ticks the server has not produced are rejected before any routing.
+    [NebulaUnitTest]
+    public void Ack_BeyondCurrentTick_IsRejected()
+    {
+        using var f = new Fixture();
+        var (node, rec) = f.RecordingNode();
+        f.World.CurrentTick = 5;
+        f.World.RegisterSentNodeForTests(f.PeerId, 5, node.Network);
+
+        f.World.PeerAcknowledge(f.Peer, 6);
+
+        Assert.Empty(rec.AckedTicks);
+    }
+}

--- a/addons/Nebula/Testing/Unit/PeerAckRingTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/PeerAckRingTests.cs.uid
@@ -1,0 +1,1 @@
+uid://bm63krd3q3v01

--- a/addons/Nebula/Testing/Unit/PropsBudgetTests.cs
+++ b/addons/Nebula/Testing/Unit/PropsBudgetTests.cs
@@ -150,9 +150,8 @@ public class PropsBudgetTests
         f.Serializer.CommitExport(f.World, f.Peer, 5);
         Assert.Equal(0b11, f.Serializer.PendingDirtyByteForTests(f.PeerId, 0));
 
-        bool stillPending = f.Serializer.Acknowledge(f.World, f.Peer, 5);
+        f.Serializer.Acknowledge(f.World, f.Peer, 5);
 
-        Assert.False(stillPending);
         Assert.Equal(0, f.Serializer.PendingDirtyByteForTests(f.PeerId, 0));
     }
 
@@ -176,13 +175,12 @@ public class PropsBudgetTests
         buf.Reset();
         Assert.Equal(ExportResult.None, f.Serializer.Export(f.World, f.Peer, buf, 0));
 
-        bool stillPending = f.Serializer.Acknowledge(f.World, f.Peer, 6);
+        f.Serializer.Acknowledge(f.World, f.Peer, 6);
 
-        Assert.True(stillPending);
         Assert.Equal(0b11, f.Serializer.PendingDirtyByteForTests(f.PeerId, 0));
 
         // The genuine send-tick ack still lands
-        Assert.False(f.Serializer.Acknowledge(f.World, f.Peer, 5));
+        f.Serializer.Acknowledge(f.World, f.Peer, 5);
         Assert.Equal(0, f.Serializer.PendingDirtyByteForTests(f.PeerId, 0));
     }
 }

--- a/addons/Nebula/Testing/Unit/SentNodeRingTests.cs
+++ b/addons/Nebula/Testing/Unit/SentNodeRingTests.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using Nebula;
+using Nebula.Serialization;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// The per-peer ack routing ring: a tick's slot must hand back exactly the nodes registered
+/// under that tick, never a wrapped older tick's, and must do so without allocating once warm.
+/// </summary>
+[NebulaUnitTest]
+public class SentNodeRingTests
+{
+    private static NetworkController Controller()
+    {
+        var node = new NetNode();
+        return node.Network;
+    }
+
+    [NebulaUnitTest]
+    public void BeginAddTryGet_RoundTrips()
+    {
+        var ring = new SentNodeRing();
+        var a = Controller();
+        var b = Controller();
+
+        ring.Begin(5);
+        ring.Add(a);
+        ring.Add(b);
+
+        Assert.True(ring.TryGet(5, out var nodes));
+        Assert.Equal(2, nodes.Count);
+        Assert.Same(a, nodes[0]);
+        Assert.Same(b, nodes[1]);
+
+        a.RawNode.Free();
+        b.RawNode.Free();
+    }
+
+    [NebulaUnitTest]
+    public void UnbegunTick_IsNotFound()
+    {
+        var ring = new SentNodeRing();
+        ring.Begin(5);
+
+        Assert.False(ring.TryGet(4, out _));
+        Assert.False(ring.TryGet(6, out _));
+        Assert.False(ring.TryGet(-1, out _));
+    }
+
+    [NebulaUnitTest]
+    public void TickZero_IsAValidSlot()
+    {
+        // Stamps start at -1 precisely so that tick 0 (the first tick a young world can be
+        // acked for) is distinguishable from "never written".
+        var ring = new SentNodeRing();
+        Assert.False(ring.TryGet(0, out _));
+
+        var a = Controller();
+        ring.Begin(0);
+        ring.Add(a);
+        Assert.True(ring.TryGet(0, out var nodes));
+        Assert.Single(nodes);
+
+        a.RawNode.Free();
+    }
+
+    [NebulaUnitTest]
+    public void WrappedTick_IsNotMistakenForItsSuccessor()
+    {
+        var ring = new SentNodeRing();
+        var a = Controller();
+        var b = Controller();
+
+        ring.Begin(5);
+        ring.Add(a);
+        ring.Begin(5 + SentNodeRing.Depth); // same slot
+        ring.Add(b);
+
+        Assert.False(ring.TryGet(5, out _));
+        Assert.True(ring.TryGet(5 + SentNodeRing.Depth, out var nodes));
+        Assert.Single(nodes);
+        Assert.Same(b, nodes[0]);
+
+        a.RawNode.Free();
+        b.RawNode.Free();
+    }
+
+    [NebulaUnitTest]
+    public void Begin_ClearsAReusedSlot_AndReusesItsList()
+    {
+        var ring = new SentNodeRing();
+        var a = Controller();
+
+        ring.Begin(1);
+        ring.Add(a);
+        Assert.True(ring.TryGet(1, out var first));
+
+        ring.Begin(1 + SentNodeRing.Depth);
+        Assert.True(ring.TryGet(1 + SentNodeRing.Depth, out var second));
+
+        Assert.Same(first, second);   // no allocation on reuse
+        Assert.Empty(second);         // and nothing carried over
+
+        a.RawNode.Free();
+    }
+
+    [NebulaUnitTest]
+    public void Reset_ForgetsEveryTick()
+    {
+        var ring = new SentNodeRing();
+        var a = Controller();
+        for (int t = 0; t < SentNodeRing.Depth; t++)
+        {
+            ring.Begin(t);
+            ring.Add(a);
+        }
+
+        ring.Reset();
+
+        for (int t = 0; t < SentNodeRing.Depth; t++)
+        {
+            Assert.False(ring.TryGet(t, out _));
+        }
+
+        a.RawNode.Free();
+    }
+}

--- a/addons/Nebula/Testing/Unit/SentNodeRingTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/SentNodeRingTests.cs.uid
@@ -1,0 +1,1 @@
+uid://bnffkdmxg077p


### PR DESCRIPTION
- Ensure "ack" handling is per relevant node rather than every node for every peer on every ack