### PR TITLE
Two-level presence mask encoding for props sections

### DIFF
--- a/addons/Nebula/Core/Serialization/PresenceMask.cs
+++ b/addons/Nebula/Core/Serialization/PresenceMask.cs
@@ -1,0 +1,125 @@
+using System;
+using Nebula.Serialization.Serializers;
+
+namespace Nebula.Serialization
+{
+    /// <summary>
+    /// Wire encoding of a props section's presence mask (which of a scene's properties the
+    /// section carries), shared by the server writer and the client reader so the two can
+    /// never disagree.
+    ///
+    /// <para>A scene with N properties has a mask of <c>ceil(N/8)</c> bytes, and a typical
+    /// section sets two or three bits of it: a 60-property player scene paid an 8-byte mask
+    /// every tick to say that position and rotation changed. So for wide masks the wire
+    /// carries a one-byte HEADER whose bit i means "mask byte i is nonzero", followed by only
+    /// those bytes, in ascending order. The property index layout clusters a node's hot
+    /// properties into one or two mask bytes, which is what makes this pay: 8 bytes become 2.</para>
+    ///
+    /// <para>Narrow masks stay flat. With one or two mask bytes, <c>1 + nonzero</c> can never
+    /// come in under the flat width, so the header would only ever cost. Both sides derive the
+    /// rule from the mask width alone - no per-section flag byte.</para>
+    ///
+    /// <para>The same scheme already exists for NetArray's chunked bool sync (one presence byte
+    /// per eight words, client zero-fills); this is the property-mask version of it.</para>
+    /// </summary>
+    internal static class PresenceMask
+    {
+        /// <summary>
+        /// Smallest mask width (in bytes) that uses the two-level encoding. Below this the
+        /// header byte cannot win: at width 2 a single nonzero byte already costs the full flat
+        /// width (1 + 1), and two nonzero bytes cost more (1 + 2).
+        /// </summary>
+        public const int TwoLevelMinBytes = 3;
+
+        /// <summary>The header is one byte, so it can name at most eight mask bytes.</summary>
+        public const int HeaderBytes = 1;
+
+        /// <summary>
+        /// Widest mask this encoding supports: one header bit per mask byte. Equal to the
+        /// scene property ceiling (<see cref="BitConstants.MaxSceneProperties"/> = 64 bits), so
+        /// nothing the generator admits can exceed it.
+        /// </summary>
+        public const int MaxMaskBytes = BitConstants.MaxSceneProperties / BitConstants.BitsInByte;
+
+        public static bool UsesTwoLevel(int byteCount) => byteCount >= TwoLevelMinBytes;
+
+        /// <summary>
+        /// Bytes the writer must reserve before the mask's contents are known: the flat width,
+        /// or header plus every mask byte when all of them turn out nonzero.
+        /// </summary>
+        public static int ReservedBytes(int byteCount)
+            => UsesTwoLevel(byteCount) ? HeaderBytes + byteCount : byteCount;
+
+        /// <summary>
+        /// Encodes <paramref name="mask"/> into <paramref name="dst"/> and returns the bytes
+        /// written. <paramref name="dst"/> must hold at least <see cref="ReservedBytes"/>.
+        /// </summary>
+        public static int Encode(ReadOnlySpan<byte> mask, Span<byte> dst)
+        {
+            if (mask.Length > MaxMaskBytes)
+            {
+                throw new InvalidOperationException(
+                    $"Presence mask of {mask.Length} bytes exceeds the {MaxMaskBytes}-byte ceiling.");
+            }
+
+            if (!UsesTwoLevel(mask.Length))
+            {
+                mask.CopyTo(dst);
+                return mask.Length;
+            }
+
+            byte header = 0;
+            int written = HeaderBytes;
+            for (int i = 0; i < mask.Length; i++)
+            {
+                if (mask[i] == 0) continue;
+                header |= (byte)(1 << i);
+                dst[written++] = mask[i];
+            }
+            dst[0] = header;
+            return written;
+        }
+
+        /// <summary>
+        /// Reads a mask of exactly <c>mask.Length</c> bytes from <paramref name="buffer"/>.
+        /// Every byte of <paramref name="mask"/> is written - the ones the header does not
+        /// name are zeroed - so a caller may hand in reused scratch without clearing it.
+        ///
+        /// <para>Runs on untrusted bytes. Returns false, having consumed only the header, when
+        /// the header names a byte beyond the mask's width: the stream cannot be realigned
+        /// from there, so the caller must abort the whole tick import rather than continue.</para>
+        /// </summary>
+        public static bool Decode(NetBuffer buffer, Span<byte> mask)
+        {
+            if (mask.Length > MaxMaskBytes)
+            {
+                throw new InvalidOperationException(
+                    $"Presence mask of {mask.Length} bytes exceeds the {MaxMaskBytes}-byte ceiling.");
+            }
+
+            if (!UsesTwoLevel(mask.Length))
+            {
+                for (int i = 0; i < mask.Length; i++)
+                {
+                    mask[i] = NetReader.ReadByte(buffer);
+                }
+                return true;
+            }
+
+            byte header = NetReader.ReadByte(buffer);
+            // A header bit at or above the width names a byte that does not exist. (For an
+            // 8-byte mask the shift yields 0 for any byte value, which is correct: every bit
+            // is in range.)
+            if ((header >> mask.Length) != 0)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < mask.Length; i++)
+            {
+                mask[i] = (header & (1 << i)) != 0 ? NetReader.ReadByte(buffer) : (byte)0;
+            }
+            return true;
+        }
+    }
+}

--- a/addons/Nebula/Core/Serialization/PresenceMask.cs.uid
+++ b/addons/Nebula/Core/Serialization/PresenceMask.cs.uid
@@ -1,0 +1,1 @@
+uid://d3joqgq7tgkpd

--- a/addons/Nebula/Core/Serialization/Serializers/NetPropertiesSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/NetPropertiesSerializer.cs
@@ -222,6 +222,15 @@ namespace Nebula.Serialization.Serializers
         /// <summary>Pre-cached size in bytes of the property presence mask.</summary>
         private readonly int _byteCount;
 
+        /// <summary>
+        /// Bytes reserved at the head of a section for the presence mask before its contents
+        /// are known: <see cref="PresenceMask.ReservedBytes"/> of <see cref="_byteCount"/>.
+        /// Wide masks ship two-level (header + nonzero bytes), so the reservation is the
+        /// worst case and the section is compacted once the mask is final. Every budget check
+        /// measures against this width, never the compact one - see the backfill in ExportCore.
+        /// </summary>
+        private readonly int _reservedMaskBytes;
+
         /// <summary>Pre-cached: does this scene have any object (INetSerializable) properties?</summary>
         private readonly bool _hasObjectProps;
 
@@ -266,7 +275,8 @@ namespace Nebula.Serialization.Serializers
         /// <summary>
         /// The smallest possible property write: a DeltaEncodingFlags byte plus a
         /// one-byte value (e.g. bool). A section budget below
-        /// [presence mask + <see cref="AGE_HEADER_BYTES"/> + this] cannot ship anything.
+        /// [<see cref="_reservedMaskBytes"/> + <see cref="AGE_HEADER_BYTES"/> + this] cannot
+        /// ship anything.
         /// </summary>
         private const int MIN_PROPERTY_WRITE_BYTES = 2;
 
@@ -344,6 +354,7 @@ namespace Nebula.Serialization.Serializers
             // server that spawned nothing while the unit suite stayed green, because the
             // suite only exercises the Protocol-free ctor.
             _byteCount = (_propertyCount + BitConstants.BitsInByte - 1) / BitConstants.BitsInByte;
+            _reservedMaskBytes = PresenceMask.ReservedBytes(_byteCount);
 
             _propSupportsDelta = new bool[_propertyCount];
             _propIsNodeRef = new bool[_propertyCount];
@@ -880,6 +891,7 @@ namespace Nebula.Serialization.Serializers
 
             _propertyCount = propTypes.Length;
             _byteCount = (_propertyCount + BitConstants.BitsInByte - 1) / BitConstants.BitsInByte;
+            _reservedMaskBytes = PresenceMask.ReservedBytes(_byteCount);
 
             _propTypes = propTypes;
             _propSupportsDelta = new bool[_propertyCount];
@@ -983,14 +995,22 @@ namespace Nebula.Serialization.Serializers
             int startPos = buffer.ReadPosition;
             int byteCount = _byteCount;
 
-            // Decode into reusable scratch. _incomingMask is fully overwritten by the read
-            // below; _decodedMask must be cleared because it accumulates as we decode.
+            // Decode into reusable scratch. _incomingMask is fully overwritten by the decode
+            // below - a flat read writes every byte, and the two-level decode zeroes the
+            // bytes its header skips (a stale bit left from the previous payload would read
+            // as a present property and misparse everything after it). _decodedMask must be
+            // cleared because it accumulates as we decode.
             byte[] propertiesUpdated = _incomingMask;
             Array.Clear(_decodedMask, 0, byteCount);
 
-            for (int i = 0; i < byteCount; i++)
+            if (!PresenceMask.Decode(buffer, propertiesUpdated.AsSpan(0, byteCount)))
             {
-                propertiesUpdated[i] = NetReader.ReadByte(buffer);
+                // Unlike a bad age byte (consumed either way, so parsing can continue and
+                // discard), a header naming a byte beyond the mask leaves the stream
+                // unalignable. Throwing lands in ImportState's per-serializer catch, which
+                // logs with node context and aborts the tick import un-acked.
+                throw new InvalidOperationException(
+                    $"NetId={network.NetId} corrupt presence-mask header for a {byteCount}-byte mask; the section cannot be realigned.");
             }
 
             // ============================================================
@@ -2070,7 +2090,16 @@ namespace Nebula.Serialization.Serializers
             // (initial sync, per-peer overrides, lossy settles, existing pending bits)
             // re-derive next tick, so over-merging them here is harmless. Object props
             // keep their own resumable per-peer state and need nothing.
-            if (maxBytes < byteCount + AGE_HEADER_BYTES + MIN_PROPERTY_WRITE_BYTES)
+            //
+            // Measured against the RESERVED mask width (worst case), as is every budget
+            // check below. The compact width is unknowable until the mask is final: an
+            // object write later in this call can set a bit in a mask byte the primitives
+            // left empty, so any estimate taken here could still grow, and a section that
+            // ends over maxBytes is dropped by the host after the memo stamps and chunk
+            // frontiers have already advanced. The pessimism is bounded (reserved minus
+            // compact, at most 7 bytes for a 64-prop scene) and only ever defers a tail
+            // node one tick earlier; it can never make a section unshippable.
+            if (maxBytes < _reservedMaskBytes + AGE_HEADER_BYTES + MIN_PROPERTY_WRITE_BYTES)
             {
                 for (var i = 0; i < byteCount; i++)
                 {
@@ -2171,9 +2200,13 @@ namespace Nebula.Serialization.Serializers
             // RESERVE-AND-BACKFILL PATTERN
             // ============================================================
 
-            // Reserve space for the mask (we'll backfill it after writing properties)
+            // Reserve the mask's WORST-CASE width; the backfill writes the compact encoding
+            // and shifts the body down over any slack. Everything below that measures the
+            // section (`WritePosition - maskStartPos`) sees the reserved width, which is the
+            // conservative side of every budget decision.
             int maskStartPos = buffer.WritePosition;
-            for (var i = 0; i < byteCount; i++)
+            int reservedMaskBytes = _reservedMaskBytes;
+            for (var i = 0; i < reservedMaskBytes; i++)
             {
                 NetWriter.WriteByte(buffer, 0); // Placeholder
             }
@@ -2207,7 +2240,7 @@ namespace Nebula.Serialization.Serializers
                     if (candidate.MaskSig == writtenPrimMask
                         && candidate.UseDeltaSig == useDeltaMask
                         && candidate.Age == (byte)baselineAge
-                        && byteCount + candidate.BlobLen <= maxBytes)
+                        && reservedMaskBytes + candidate.BlobLen <= maxBytes)
                     {
                         memoHit = m;
                         break;
@@ -2355,16 +2388,16 @@ namespace Nebula.Serialization.Serializers
                     // missed an input, which is the one failure mode this cache cannot
                     // afford - latch the memo off for the whole run and say so loudly.
                     ref var verifyEntry = ref _memo[memoHit];
-                    int writtenLen = buffer.WritePosition - (maskStartPos + byteCount);
+                    int writtenLen = buffer.WritePosition - (maskStartPos + reservedMaskBytes);
                     bool identical = writtenLen == verifyEntry.BlobLen
-                        && buffer.RawBuffer.AsSpan(maskStartPos + byteCount, writtenLen)
+                        && buffer.RawBuffer.AsSpan(maskStartPos + reservedMaskBytes, writtenLen)
                             .SequenceEqual(verifyEntry.Blob.AsSpan(0, verifyEntry.BlobLen));
                     if (!identical)
                     {
                         _memoDisabled = true;
                         Debugger.Instance.Log(
                             $"[MemoVerify] DIVERGENCE on {_cachedSceneFilePath}: sig=(mask={writtenPrimMask:X}, delta={useDeltaMask:X}, age={baselineAge}) "
-                            + $"slow={Convert.ToHexString(buffer.RawBuffer.AsSpan(maskStartPos + byteCount, writtenLen))} "
+                            + $"slow={Convert.ToHexString(buffer.RawBuffer.AsSpan(maskStartPos + reservedMaskBytes, writtenLen))} "
                             + $"memo={Convert.ToHexString(verifyEntry.Blob.AsSpan(0, verifyEntry.BlobLen))}. "
                             + "Section memo disabled for this run; the signature is missing an input.",
                             Debugger.DebugLevel.ERROR);
@@ -2387,12 +2420,12 @@ namespace Nebula.Serialization.Serializers
                         slot.MaskSig = writtenPrimMask;
                         slot.UseDeltaSig = useDeltaMask;
                         slot.Age = (byte)baselineAge;
-                        int blobLen = buffer.WritePosition - (maskStartPos + byteCount);
+                        int blobLen = buffer.WritePosition - (maskStartPos + reservedMaskBytes);
                         if (slot.Blob == null || slot.Blob.Length < blobLen)
                         {
                             slot.Blob = new byte[Math.Max(blobLen, 256)];
                         }
-                        buffer.RawBuffer.AsSpan(maskStartPos + byteCount, blobLen).CopyTo(slot.Blob);
+                        buffer.RawBuffer.AsSpan(maskStartPos + reservedMaskBytes, blobLen).CopyTo(slot.Blob);
                         slot.BlobLen = blobLen;
                         slot.LossyResultMask = lossyResultBits;
                     }
@@ -2549,16 +2582,33 @@ namespace Nebula.Serialization.Serializers
                 return ExportResult.None;
             }
 
-            // BACKFILL: Go back and write the actual mask
-            // We need to overwrite the placeholder bytes we wrote earlier
-            // NetWriter writes at WritePosition, so we save it, set to maskStartPos, write, then restore
+            // BACKFILL: the mask is final now, so encode it compactly over the placeholder.
+            // A wide mask ships as [header][nonzero bytes] (see PresenceMask), which is
+            // usually far narrower than the reserved worst case; the body is then shifted
+            // down over the slack with one overlapping copy (bodies are tens of bytes).
+            // Nothing records an absolute buffer position during the write - object
+            // serializers stamp per-peer frontiers, the memo captured its blob above - so
+            // moving the body is safe. Only the host's TryAppendSection reads the section,
+            // and it reads WritePosition after this returns.
             int endPos = buffer.WritePosition;
-            buffer.WritePosition = maskStartPos;
-            for (var i = 0; i < byteCount; i++)
+            Span<byte> compactMask = stackalloc byte[PresenceMask.HeaderBytes + PresenceMask.MaxMaskBytes];
+            int compactLen = PresenceMask.Encode(actualMask.AsSpan(0, byteCount), compactMask);
+            compactMask.Slice(0, compactLen).CopyTo(buffer.RawBuffer.AsSpan(maskStartPos, compactLen));
+            int maskSlack = reservedMaskBytes - compactLen;
+            if (maskSlack > 0)
             {
-                NetWriter.WriteByte(buffer, actualMask[i]);
+                int bodyStart = maskStartPos + reservedMaskBytes;
+                int bodyLen = endPos - bodyStart;
+                buffer.RawBuffer.AsSpan(bodyStart, bodyLen).CopyTo(buffer.RawBuffer.AsSpan(bodyStart - maskSlack, bodyLen));
+                endPos -= maskSlack;
             }
             buffer.WritePosition = endPos;
+            if (TraceWire)
+            {
+                // The per-property [Props.W] `end=` offsets above are reserved-relative; this
+                // line is what reconciles them against the client's [Props.R] positions.
+                Debugger.Instance.Log($"[Props.W] mask={Convert.ToHexString(compactMask.Slice(0, compactLen))} reserved={reservedMaskBytes} compact={compactLen} sectionLen={endPos - maskStartPos}");
+            }
 
             // Packet-coupled stamps (SentHistory, shipped-bit pending, initial sync,
             // per-peer dirty clears) apply in CommitExport once the host commits these

--- a/addons/Nebula/Core/WorldRunner.cs
+++ b/addons/Nebula/Core/WorldRunner.cs
@@ -3269,8 +3269,9 @@ namespace Nebula
         /// <summary>
         /// Props phase stops serving (and defers the rest of the rotation) once the
         /// remaining section budget drops below this. Ceiling of the smallest useful
-        /// props section: presence mask (max 64 props = 8 bytes) + age byte + smallest
-        /// property write (2 bytes), rounded up for slack.
+        /// props section: presence mask reservation (max 64 props = 8 bytes, plus the
+        /// two-level header = 9; see PresenceMask) + age byte + smallest property write
+        /// (2 bytes), rounded up for slack.
         /// </summary>
         private const int PropsSectionFloor = 16;
 

--- a/addons/Nebula/Testing/Unit/PresenceMaskTests.cs
+++ b/addons/Nebula/Testing/Unit/PresenceMaskTests.cs
@@ -1,0 +1,177 @@
+using System;
+using Nebula;
+using Nebula.Serialization;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// The presence-mask wire encoding as pure byte logic: flat below three mask bytes, header
+/// plus nonzero bytes from three up. The failure that matters on the read side is a byte the
+/// header skips being left stale, so the decode tests hand in a scratch full of 0xFF.
+/// </summary>
+[NebulaUnitTest]
+public class PresenceMaskTests
+{
+    private static NetBuffer Wire(params byte[] bytes)
+    {
+        var buf = new NetBuffer(32, usePool: false);
+        foreach (var b in bytes) NetWriter.WriteByte(buf, b);
+        buf.ResetRead();
+        return buf;
+    }
+
+    [NebulaUnitTest]
+    public void Rule_FlatBelowThree_TwoLevelFromThree()
+    {
+        Assert.False(PresenceMask.UsesTwoLevel(1));
+        Assert.False(PresenceMask.UsesTwoLevel(2));
+        for (int w = 3; w <= PresenceMask.MaxMaskBytes; w++)
+        {
+            Assert.True(PresenceMask.UsesTwoLevel(w));
+            Assert.Equal(1 + w, PresenceMask.ReservedBytes(w));
+        }
+        Assert.Equal(1, PresenceMask.ReservedBytes(1));
+        Assert.Equal(2, PresenceMask.ReservedBytes(2));
+    }
+
+    [NebulaUnitTest]
+    public void Encode_Flat_CopiesBytes()
+    {
+        Span<byte> dst = stackalloc byte[4];
+        int len = PresenceMask.Encode(new byte[] { 0x00, 0xA5 }, dst);
+        Assert.Equal(2, len);
+        Assert.Equal(0x00, dst[0]);
+        Assert.Equal(0xA5, dst[1]);
+    }
+
+    [NebulaUnitTest]
+    public void Encode_AllZero_IsOneZeroHeader()
+    {
+        Span<byte> dst = stackalloc byte[9];
+        int len = PresenceMask.Encode(new byte[8], dst);
+        Assert.Equal(1, len);
+        Assert.Equal(0, dst[0]);
+    }
+
+    [NebulaUnitTest]
+    public void Encode_SingleNonzeroByte_IsHeaderPlusThatByte()
+    {
+        for (int i = 0; i < 8; i++)
+        {
+            var mask = new byte[8];
+            mask[i] = 0x40;
+            Span<byte> dst = stackalloc byte[9];
+            int len = PresenceMask.Encode(mask, dst);
+            Assert.Equal(2, len);
+            Assert.Equal((byte)(1 << i), dst[0]);
+            Assert.Equal(0x40, dst[1]);
+        }
+    }
+
+    [NebulaUnitTest]
+    public void Encode_NonzeroBytes_ComeOutAscending()
+    {
+        var mask = new byte[] { 0, 0x11, 0, 0, 0x22, 0, 0x33, 0 };
+        Span<byte> dst = stackalloc byte[9];
+        int len = PresenceMask.Encode(mask, dst);
+        Assert.Equal(4, len);
+        Assert.Equal(0b0101_0010, dst[0]);
+        Assert.Equal(0x11, dst[1]);
+        Assert.Equal(0x22, dst[2]);
+        Assert.Equal(0x33, dst[3]);
+    }
+
+    [NebulaUnitTest]
+    public void Encode_AllNonzero_CostsOneMoreThanFlat()
+    {
+        var mask = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+        Span<byte> dst = stackalloc byte[9];
+        int len = PresenceMask.Encode(mask, dst);
+        Assert.Equal(9, len);
+        Assert.Equal(0xFF, dst[0]);
+        for (int i = 0; i < 8; i++) Assert.Equal(mask[i], dst[1 + i]);
+    }
+
+    [NebulaUnitTest]
+    public void Decode_ZeroFillsSkippedBytes()
+    {
+        // Header names bytes 1 and 4 of a 6-byte mask; the scratch starts dirty.
+        var scratch = new byte[6];
+        Array.Fill(scratch, (byte)0xFF);
+        var wire = Wire(0b0001_0010, 0xAA, 0xBB, 0x99);
+
+        Assert.True(PresenceMask.Decode(wire, scratch));
+        Assert.Equal(new byte[] { 0, 0xAA, 0, 0, 0xBB, 0 }, scratch);
+        Assert.Equal(3, wire.ReadPosition);   // the trailing 0x99 is not part of the mask
+    }
+
+    [NebulaUnitTest]
+    public void Decode_ZeroHeader_ConsumesOneByte_ZeroFillsAll()
+    {
+        var scratch = new byte[3];
+        Array.Fill(scratch, (byte)0xFF);
+        var wire = Wire(0x00, 0x77);
+
+        Assert.True(PresenceMask.Decode(wire, scratch));
+        Assert.Equal(new byte[] { 0, 0, 0 }, scratch);
+        Assert.Equal(1, wire.ReadPosition);
+    }
+
+    [NebulaUnitTest]
+    public void Decode_Flat_ReadsEveryByte()
+    {
+        var scratch = new byte[2];
+        var wire = Wire(0x12, 0x34);
+        Assert.True(PresenceMask.Decode(wire, scratch));
+        Assert.Equal(new byte[] { 0x12, 0x34 }, scratch);
+        Assert.Equal(2, wire.ReadPosition);
+    }
+
+    [NebulaUnitTest]
+    public void Decode_HeaderBitBeyondWidth_IsRejected_ScratchUntouched()
+    {
+        var scratch = new byte[] { 0xFF, 0xFF, 0xFF };
+        var wire = Wire(0b0000_1000, 0x01);   // bit 3 names a 4th byte of a 3-byte mask
+
+        Assert.False(PresenceMask.Decode(wire, scratch));
+        Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF }, scratch);
+        Assert.Equal(1, wire.ReadPosition);   // only the header was consumed
+    }
+
+    [NebulaUnitTest]
+    public void Decode_FullWidthHeader_IsInRange()
+    {
+        var scratch = new byte[8];
+        var wire = Wire(0xFF, 1, 2, 3, 4, 5, 6, 7, 8);
+        Assert.True(PresenceMask.Decode(wire, scratch));
+        Assert.Equal(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }, scratch);
+    }
+
+    [NebulaUnitTest]
+    public void RoundTrip_EveryWidth()
+    {
+        var rng = new Random(77);
+        for (int width = 1; width <= PresenceMask.MaxMaskBytes; width++)
+        {
+            for (int round = 0; round < 32; round++)
+            {
+                var mask = new byte[width];
+                for (int i = 0; i < width; i++) mask[i] = rng.Next(3) == 0 ? (byte)rng.Next(1, 256) : (byte)0;
+
+                var dst = new byte[PresenceMask.ReservedBytes(width)];
+                int len = PresenceMask.Encode(mask, dst);
+                Assert.True(len <= dst.Length);
+
+                var wire = new NetBuffer(16, usePool: false);
+                NetWriter.WriteBytes(wire, dst.AsSpan(0, len));
+                wire.ResetRead();
+                var back = new byte[width];
+                Array.Fill(back, (byte)0xFF);
+                Assert.True(PresenceMask.Decode(wire, back));
+                Assert.Equal(mask, back);
+                Assert.Equal(len, wire.ReadPosition);
+            }
+        }
+    }
+}

--- a/addons/Nebula/Testing/Unit/PresenceMaskTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/PresenceMaskTests.cs.uid
@@ -1,0 +1,1 @@
+uid://cufivgilavale

--- a/addons/Nebula/Testing/Unit/PropsMaskWireTests.cs
+++ b/addons/Nebula/Testing/Unit/PropsMaskWireTests.cs
@@ -1,0 +1,247 @@
+using System;
+using Nebula;
+using Nebula.Serialization;
+using Nebula.Serialization.Serializers;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// The props section with a WIDE presence mask (three bytes and up), which every other props
+/// fixture in the suite never reaches (they declare one to four properties). Covers the
+/// two-level mask on the wire, the reserve-and-shift backfill, its interplay with the section
+/// memo and the self-limiting budget, and the read side's header validation.
+///
+/// Value decoding needs the Protocol registry, so the read-side tests stop at the mask and
+/// age bytes; the encoder itself is covered byte-for-byte in PresenceMaskTests.
+/// </summary>
+[NebulaUnitTest]
+public class PropsMaskWireTests
+{
+    private const byte AbsoluteAge = 0;
+
+    private sealed class Fixture : IDisposable
+    {
+        public WorldRunner World;
+        public NetPeer Peer;      // default(NetPeer): ID 0, mapped in PeerIds below
+        public UUID PeerId;
+        public NetNode Node;
+        public NetPropertiesSerializer Serializer;
+        public int PropertyCount;
+
+        public Fixture(int intProps)
+        {
+            var propTypes = Ints(intProps);
+            PropertyCount = intProps;
+            World = new WorldRunner();
+            Peer = default;
+            PeerId = UUID.NewUUID();
+            NetRunner.Instance.PeerIds[0] = PeerId;
+            World.CreatePeerStateForTests(Peer, PeerId);
+
+            Node = new NetNode();
+            Node.Network.InterestLayers[PeerId] = 1;
+            Node.Network.CurrentWorld = World;
+            for (var i = 0; i < propTypes.Length; i++)
+            {
+                Node.Network.CachedProperties[i] = new PropertyCache { Type = propTypes[i], IntValue = 40 + i };
+            }
+            Serializer = new NetPropertiesSerializer(Node.Network, propTypes);
+            World.SetClientSpawnState(Node.Network.NetId, Peer, WorldRunner.ClientSpawnState.Spawning);
+        }
+
+        /// <summary>One export at the given tick with exactly these property indices dirty.</summary>
+        public ExportResult Export(int tick, NetBuffer buf, int maxBytes, params int[] dirtyIndices)
+        {
+            long dirty = 0;
+            foreach (var i in dirtyIndices) dirty |= 1L << i;
+            World.CurrentTick = tick;
+            Node.Network.DirtyMask = dirty;
+            Serializer.Begin();
+            return Serializer.Export(World, Peer, buf, maxBytes);
+        }
+
+        public void Dispose()
+        {
+            NetRunner.Instance.PeerIds.Remove(0);
+            Node.Free();
+            World.Free();
+        }
+    }
+
+    private static SerialVariantType[] Ints(int n)
+    {
+        var types = new SerialVariantType[n];
+        Array.Fill(types, SerialVariantType.Int);
+        return types;
+    }
+
+    private static NetBuffer Buffer() => new(1024, usePool: false);
+
+    // 1. Three mask bytes, one dirty prop in the third: header + one mask byte, then the age.
+    [NebulaUnitTest]
+    public void OneDirtyByte_ShipsHeaderPlusOneMaskByte()
+    {
+        using var f = new Fixture(24);
+        var buf = Buffer();
+
+        Assert.Equal(ExportResult.Written, f.Export(1, buf, int.MaxValue, 20));
+
+        var span = buf.WrittenSpan;
+        Assert.Equal(0b100, span[0]);        // only mask byte 2 is nonzero
+        Assert.Equal(0x10, span[1]);         // index 20 = byte 2, bit 4
+        Assert.Equal(AbsoluteAge, span[2]);
+        Assert.True(span.Length > 3);        // a value follows
+    }
+
+    // 2. Dirty props in two different mask bytes: both listed, ascending.
+    [NebulaUnitTest]
+    public void TwoDirtyBytes_HeaderListsBothAscending()
+    {
+        using var f = new Fixture(24);
+        var buf = Buffer();
+
+        Assert.Equal(ExportResult.Written, f.Export(1, buf, int.MaxValue, 0, 20));
+
+        var span = buf.WrittenSpan;
+        Assert.Equal(0b101, span[0]);
+        Assert.Equal(0x01, span[1]);
+        Assert.Equal(0x10, span[2]);
+        Assert.Equal(AbsoluteAge, span[3]);
+    }
+
+    // 3. The player's real shape: 60 props, ship transform in byte 5 and character movement
+    //    in byte 6. Indices 46 and 48 dirty -> header names bytes 5 and 6.
+    [NebulaUnitTest]
+    public void PlayerShape_ShipAndCharacterBytes()
+    {
+        using var f = new Fixture(60);
+        var buf = Buffer();
+
+        Assert.Equal(ExportResult.Written, f.Export(1, buf, int.MaxValue, 46, 48));
+
+        var span = buf.WrittenSpan;
+        Assert.Equal(0b0110_0000, span[0]);
+        Assert.Equal(0x40, span[1]);   // byte 5: index 46 = bit 6
+        Assert.Equal(0x01, span[2]);   // byte 6: index 48 = bit 0
+        Assert.Equal(AbsoluteAge, span[3]);
+    }
+
+    // 4. The section is exactly as long as [compact mask][age][values]: compare two exports
+    //    of the same single value whose only difference is which mask byte it lives in.
+    //    Byte 0 vs byte 2 must cost the same, and one extra dirty byte must cost exactly
+    //    one more mask byte plus one value.
+    [NebulaUnitTest]
+    public void SectionLength_TracksCompactMaskExactly()
+    {
+        int single0, single20, both;
+        using (var f = new Fixture(24))
+        {
+            var a = Buffer();
+            f.Export(1, a, int.MaxValue, 0);
+            single0 = a.WrittenSpan.Length;
+        }
+        using (var f = new Fixture(24))
+        {
+            var b = Buffer();
+            f.Export(1, b, int.MaxValue, 20);
+            single20 = b.WrittenSpan.Length;
+        }
+        using (var f = new Fixture(24))
+        {
+            var c = Buffer();
+            f.Export(1, c, int.MaxValue, 0, 20);
+            both = c.WrittenSpan.Length;
+        }
+
+        Assert.Equal(single0, single20);
+        int valueBytes = single0 - 2 - 1;          // minus [header][one mask byte][age]
+        Assert.True(valueBytes >= 2);
+        Assert.Equal(single0 + 1 + valueBytes, both); // one more mask byte, one more value
+    }
+
+    // 5. Memo interplay: a signature-matched second export (same tick, same dirty set) is a
+    //    memo hit and lands byte-identical, compaction included.
+    [NebulaUnitTest]
+    public void MemoHit_IsByteIdentical_AtWideMask()
+    {
+        using var f = new Fixture(24);
+        f.World.CurrentTick = 1;
+        f.Node.Network.DirtyMask = (1L << 3) | (1L << 20);
+        f.Serializer.Begin();
+
+        var first = Buffer();
+        Assert.Equal(ExportResult.Written, f.Serializer.Export(f.World, f.Peer, first, int.MaxValue));
+        Assert.Equal(0, f.Serializer.MemoHitsForTests);
+
+        var second = Buffer();
+        Assert.Equal(ExportResult.Written, f.Serializer.Export(f.World, f.Peer, second, int.MaxValue));
+        Assert.Equal(1, f.Serializer.MemoHitsForTests);
+        Assert.True(first.WrittenSpan.SequenceEqual(second.WrittenSpan));
+        Assert.Equal(0b101, second.WrittenSpan[0]);
+    }
+
+    // 6. Budget: one byte under the full section still self-limits (never exceeds
+    //    maxBytes), reports Partial, and banks the leftover. The checks measure against
+    //    the reserved (worst-case) mask width, so the shipped section is comfortably
+    //    inside the budget rather than exactly at it.
+    [NebulaUnitTest]
+    public void TightBudget_SelfLimits_AtWideMask()
+    {
+        int fullSize;
+        using (var sizing = new Fixture(24))
+        {
+            var buf = Buffer();
+            Assert.Equal(ExportResult.Written, sizing.Export(1, buf, int.MaxValue, 0, 1, 2));
+            fullSize = buf.WrittenSpan.Length;
+        }
+
+        using var f = new Fixture(24);
+        var tight = Buffer();
+        int maxBytes = fullSize - 1;
+        var result = f.Export(1, tight, maxBytes, 0, 1, 2);
+
+        Assert.Equal(ExportResult.Partial, result);
+        Assert.True(tight.WrittenSpan.Length <= maxBytes);
+        Assert.Equal(0b001, tight.WrittenSpan[0]);          // still byte 0 only
+        Assert.NotEqual(0, f.Serializer.PendingDirtyByteForTests(f.PeerId, 0));
+    }
+
+    // 7. Nothing dirty writes nothing at all - no header, no age.
+    [NebulaUnitTest]
+    public void NothingDirty_WritesNothing()
+    {
+        using var f = new Fixture(24);
+        var buf = Buffer();
+        Assert.Equal(ExportResult.None, f.Export(1, buf, int.MaxValue));
+        Assert.Equal(0, buf.WrittenSpan.Length);
+    }
+
+    // 8. Read side: an empty two-level mask is [0x00][age] and consumes exactly two bytes.
+    [NebulaUnitTest]
+    public void Decode_EmptyHeader_ConsumesHeaderAndAge()
+    {
+        using var f = new Fixture(24);
+        var wire = new NetBuffer(16, usePool: false);
+        NetWriter.WriteByte(wire, 0x00);
+        NetWriter.WriteByte(wire, AbsoluteAge);
+        wire.ResetRead();
+
+        Assert.True(f.Serializer.DeserializeForTests(wire, 1));
+        Assert.Equal(2, wire.ReadPosition);
+    }
+
+    // 9. Read side: a header naming a byte beyond the mask throws, which ImportState turns
+    //    into an aborted, un-acked tick.
+    [NebulaUnitTest]
+    public void Decode_CorruptHeader_Throws()
+    {
+        using var f = new Fixture(24);   // 3 mask bytes: header bits 0..2 are valid
+        var wire = new NetBuffer(16, usePool: false);
+        NetWriter.WriteByte(wire, 0xFF);
+        NetWriter.WriteByte(wire, AbsoluteAge);
+        wire.ResetRead();
+
+        Assert.Throws<InvalidOperationException>(() => f.Serializer.DeserializeForTests(wire, 1));
+    }
+}

--- a/addons/Nebula/Testing/Unit/PropsMaskWireTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/PropsMaskWireTests.cs.uid
@@ -1,0 +1,1 @@
+uid://dwhkyl1it2pwf

--- a/addons/Nebula/Testing/Unit/PropsMemoTests.cs
+++ b/addons/Nebula/Testing/Unit/PropsMemoTests.cs
@@ -250,23 +250,52 @@ public class PropsMemoTests
     [NebulaUnitTest]
     public void OnOffEquivalence_RandomizedSchedules()
     {
-        var peerId = UUID.NewUUID();
-        using var on = new Fixture(memoOn: true, peerId,
+        RunOnOffEquivalence(
             SerialVariantType.Int, SerialVariantType.Float, SerialVariantType.Int, SerialVariantType.Float);
-        using var off = new Fixture(memoOn: false, peerId,
-            SerialVariantType.Int, SerialVariantType.Float, SerialVariantType.Int, SerialVariantType.Float);
+    }
 
+    // 7b. The same matrix at a WIDE presence mask (24 props = 3 mask bytes, two-level on the
+    //     wire): proves the memo blob and the compacting backfill agree byte-for-byte when
+    //     the mask is being shifted under the body.
+    [NebulaUnitTest]
+    public void OnOffEquivalence_RandomizedSchedules_TwoLevelMask()
+    {
+        var types = new SerialVariantType[24];
+        for (int i = 0; i < types.Length; i++)
+        {
+            types[i] = (i % 3 == 1) ? SerialVariantType.Float : SerialVariantType.Int;
+        }
+        RunOnOffEquivalence(types);
+    }
+
+    private static void RunOnOffEquivalence(params SerialVariantType[] types)
+    {
+        var peerId = UUID.NewUUID();
+        using var on = new Fixture(memoOn: true, peerId, types);
+        using var off = new Fixture(memoOn: false, peerId, types);
+
+        long allProps = types.Length >= 64 ? -1L : (1L << types.Length) - 1;
         var rng = new Random(1234);   // fixed seed: failures must reproduce
         for (int tick = 1; tick <= 40; tick++)
         {
-            long dirty = rng.Next(1, 16);
+            // Sparse-ish dirty sets, like real traffic: each prop dirty with ~1/4 chance,
+            // never empty.
+            long dirty = 0;
+            while (dirty == 0)
+            {
+                for (int prop = 0; prop < types.Length; prop++)
+                {
+                    if (rng.Next(4) == 0) dirty |= 1L << prop;
+                }
+                dirty &= allProps;
+            }
             bool ack = rng.Next(3) == 0;
             float bump = (float)rng.NextDouble();
 
             foreach (var f in new[] { on, off })
             {
                 f.World.CurrentTick = tick;
-                for (int prop = 0; prop < 4; prop++)
+                for (int prop = 0; prop < types.Length; prop++)
                 {
                     if ((dirty & (1L << prop)) == 0) continue;
                     var cache = f.Node.Network.CachedProperties[prop];

--- a/addons/Nebula/Testing/Unit/SnapshotBaselineTests.cs
+++ b/addons/Nebula/Testing/Unit/SnapshotBaselineTests.cs
@@ -13,8 +13,10 @@ namespace Nebula.Testing.Unit;
 /// and a malformed age byte must discard rather than index the ring negatively and throw.
 ///
 /// Built on the Protocol-free test constructor; wire format per payload is
-/// [presence mask x byteCount][baselineAge byte][property data], and these tests use an
-/// empty presence mask so no property bytes follow.
+/// [presence mask][baselineAge byte][property data], where the mask is flat for scenes with
+/// one or two mask bytes (this fixture: 2 props, 1 byte) and two-level ([header][nonzero
+/// bytes], see PresenceMask) for wider ones. These tests use an empty presence mask so no
+/// property bytes follow.
 /// </summary>
 [NebulaUnitTest]
 public class SnapshotBaselineTests

--- a/addons/Nebula/plugin.cfg
+++ b/addons/Nebula/plugin.cfg
@@ -3,5 +3,5 @@
 name="Nebula"
 description="Netcode Framework for Online Multiplayer Games"
 author="Heavenlode"
-version="1.9.1"
+version="1.10.0"
 script="Tools/Main.cs"


### PR DESCRIPTION
- Add PresenceMask, the shared wire encoding for a props section's presence mask: masks of 3+ bytes ship a one-byte header naming the nonzero bytes followed by only those bytes; narrower masks stay flat. Both sides derive the rule from the mask width, so there is no per-section flag.
- Reserve the worst-case mask width in the writer and compact the section on backfill; every budget check measures the reserved width.
- Throw on a header naming a byte beyond the mask, since the stream cannot be realigned, and zero the bytes the decode skips so stale bits cannot read as present properties.
- Add PresenceMask and props mask wire tests, and extend the memo on/off equivalence test to a 24-property scene with a two-level mask.
- Bump plugin version to 1.10.0.