### PR TITLE
Add quantized wire encoding for float, vector and quaternion props

### DIFF
--- a/addons/Nebula/Core/NetProperty.cs
+++ b/addons/Nebula/Core/NetProperty.cs
@@ -100,5 +100,28 @@ namespace Nebula
         /// </list>
         /// </summary>
         public bool PerPeerState = false;
+
+        /// <summary>
+        /// Grid step for wire quantization, in the property's own units; 0 (default) keeps the
+        /// float/half-float encoding. Only float, Vector2, Vector3 and Quaternion may set it
+        /// (NEBULA010). The value is rounded to the nearest multiple of the step on the server
+        /// and replicated as integer step counts, so every delta is exact: the client
+        /// reconstructs the server's grid value bit for bit and no lossy "settle" absolute is
+        /// ever needed. A change smaller than one step is not sent at all (server-side
+        /// dead-band). For a Quaternion the step is per smallest-three component and resolves
+        /// to a bit width (at most 10 bits per component). Cannot combine with PerPeerState.
+        /// Wire encoding, so it is part of the protocol hash.
+        /// </summary>
+        public float Quantize = 0f;
+
+        /// <summary>
+        /// Vector3 only: the value is a unit direction. It is replicated as an octahedral
+        /// projection (two components in [-1, 1]) instead of three coordinates, and
+        /// <see cref="Quantize"/> is the step in those octahedral units (roughly the angular
+        /// resolution in radians / 2). Requires Quantize > 0. A zero-length input is not a
+        /// direction and is sent as +Y, so properties that use Vector3.Zero as a sentinel must
+        /// not set this. Renormalised on decode.
+        /// </summary>
+        public bool UnitVector = false;
     }
 }

--- a/addons/Nebula/Core/Nodes/NetTransform/NetTransform3D.cs
+++ b/addons/Nebula/Core/Nodes/NetTransform/NetTransform3D.cs
@@ -90,7 +90,14 @@ namespace Nebula.Utility.Nodes
         /// <summary>
         /// Networked position with interpolation for non-owned and prediction for owned entities.
         /// </summary>
-        [NetProperty(Interpolate = true, InterpolateSpeed = 1f, Predicted = true, NotifyOnChange = true)]
+        /// <remarks>
+        /// Replicated on a 1 cm grid (<c>Quantize = 0.01f</c>): the generic transform
+        /// default. A moving delta packs into one uint32 while the per-tick displacement stays
+        /// under 5.11 units per axis (~150 u/s at 30 TPS); faster movers fall back to varints
+        /// at no worse than the old half-float cost. A project wanting coarser positions
+        /// raises the step on its own subclass or property.
+        /// </remarks>
+        [NetProperty(Interpolate = true, InterpolateSpeed = 1f, Predicted = true, NotifyOnChange = true, Quantize = 0.01f)]
         public Vector3 NetPosition { get; set; }
 
         /// <summary>
@@ -103,12 +110,19 @@ namespace Nebula.Utility.Nodes
         /// <summary>
         /// Networked rotation with interpolation for non-owned and prediction for owned entities.
         /// </summary>
-        [NetProperty(Interpolate = true, InterpolateSpeed = 15f, Predicted = true, NotifyOnChange = true)]
+        /// <remarks>
+        /// Replicated as smallest-three in a uint32 (<c>Quantize = 0.002f</c> resolves to 10
+        /// bits per component, the cap): 4 bytes instead of 6, worst-case angular error
+        /// ~0.0055 rad (QuantizedCodec.MaxError).
+        /// </remarks>
+        [NetProperty(Interpolate = true, InterpolateSpeed = 15f, Predicted = true, NotifyOnChange = true, Quantize = 0.002f)]
         public Quaternion NetRotation { get; set; } = Quaternion.Identity;
 
         /// <summary>
         /// Tolerance for rotation misprediction detection.
         /// Set this from parent nodes that use NetTransform3D via composition.
+        /// The default sits ~9x above the wire's worst-case rotation error (see NetRotation);
+        /// an owner that lowers it below ~0.006 rad would reconcile on quantization noise.
         /// </summary>
         [Export]
         public float NetRotationPredictionTolerance { get; set; } = 0.05f;

--- a/addons/Nebula/Core/Serialization/NetReader.cs
+++ b/addons/Nebula/Core/Serialization/NetReader.cs
@@ -242,6 +242,22 @@ namespace Nebula.Serialization
             return new Quaternion(x, y, z, w);
         }
 
+        /// <summary>Inverse of <see cref="NetWriter.WriteZigZagVarInt"/>.</summary>
+        public static int ReadZigZagVarInt(NetBuffer buffer)
+        {
+            uint zig = 0;
+            int shift = 0;
+            while (true)
+            {
+                byte b = ReadByte(buffer);
+                zig |= (uint)(b & 0x7F) << shift;
+                if ((b & 0x80) == 0) break;
+                shift += 7;
+                if (shift > 28) throw new InvalidOperationException("ZigZag varint longer than 5 bytes");
+            }
+            return (int)(zig >> 1) ^ -(int)(zig & 1);
+        }
+
         #endregion
 
         #region Arrays and Strings

--- a/addons/Nebula/Core/Serialization/NetWriter.cs
+++ b/addons/Nebula/Core/Serialization/NetWriter.cs
@@ -240,6 +240,23 @@ namespace Nebula.Serialization
             buffer.AdvanceWrite(6);
         }
 
+        /// <summary>
+        /// Zigzag-mapped LEB128 varint: small magnitudes of either sign cost one byte, and any
+        /// int fits in five. Used for quantized property step counts (see QuantizedCodec);
+        /// nothing else in the protocol uses a varint, so this is the only place the shape
+        /// needs to be agreed on.
+        /// </summary>
+        public static void WriteZigZagVarInt(NetBuffer buffer, int value)
+        {
+            uint zig = (uint)((value << 1) ^ (value >> 31));
+            while (zig >= 0x80)
+            {
+                WriteByte(buffer, (byte)(zig | 0x80));
+                zig >>= 7;
+            }
+            WriteByte(buffer, (byte)zig);
+        }
+
         #endregion
 
         #region Arrays and Strings

--- a/addons/Nebula/Core/Serialization/QuantizedCodec.cs
+++ b/addons/Nebula/Core/Serialization/QuantizedCodec.cs
@@ -1,0 +1,428 @@
+using System;
+using Godot;
+using Nebula.Serialization.Serializers;
+
+namespace Nebula.Serialization
+{
+    /// <summary>
+    /// Wire encoding of a quantized property (<c>[NetProperty(Quantize = step)]</c>), shared by
+    /// the server writer and the client reader so the two can never disagree.
+    ///
+    /// <para>A quantized value is N signed integer step counts ("codes"): float N=1, Vector2
+    /// N=2, Vector3 N=3, unit-vector Vector3 N=2 (octahedral u, w). Codes travel either
+    /// absolute (N zigzag varints), as a SMALL delta packed into one word (3x10 bits in a
+    /// uint32, 2x12 bits in three bytes, one int16), or as a FULL delta (N zigzag varints).
+    /// Quaternions are the exception: smallest-three packed into a uint32 at
+    /// <see cref="ResolveQuatBits"/> bits per component, absolute only.</para>
+    ///
+    /// <para><b>Exactness contract.</b> Deltas are exact because both sides compute
+    /// <c>Quantize(baseline)</c> from bit-identical floats with identical code: the server's
+    /// delta ring holds <see cref="Canonicalize"/>d values, the client holds the
+    /// <see cref="Decode"/> of the codes it received, and both are the same
+    /// <c>Dequantize(codes)</c>. That does NOT require <c>Quantize(Dequantize(q)) == q</c>;
+    /// on the octahedral fold seams it is legitimately false (the mirrored code comes back),
+    /// which merely turns that tick's delta into the full form. What it does require is that
+    /// <see cref="Dequantize"/> and <see cref="OctDecode"/> are deterministic across
+    /// machines: they use only IEEE + - * / and sqrt, never a transcendental.</para>
+    ///
+    /// <para><b>Magnitude limit.</b> <c>v / step</c> is round-robust in float32 only while
+    /// <c>|v| &lt; ~0.5 * step * 2^24</c> (about 84,000 units at a 0.01 step). Beyond that the
+    /// grid is coarser than the step, still exact on the wire but no longer the declared
+    /// resolution. Codes are clamped to int range rather than left to the platform's
+    /// out-of-range float-to-int conversion, which differs between x86 and ARM.</para>
+    /// </summary>
+    internal static class QuantizedCodec
+    {
+        /// <summary>
+        /// Most bits per smallest-three component: 2 index bits + 3 * 10 fits a uint32.
+        /// </summary>
+        public const int MaxQuatBits = 10;
+        public const int MinQuatBits = 2;
+        private const int QuatIndexBits = 2;
+
+        /// <summary>Largest component count of any quantized type (Vector3).</summary>
+        public const int MaxComponents = 3;
+
+        // Small-delta word shapes. Ranges are the per-component limits; a delta outside falls
+        // back to the full varint form.
+        private const int Small3Bits = 10;
+        private const int Small3Bias = 1 << (Small3Bits - 1);          // 512
+        private const int Small3Max = Small3Bias - 1;                    // 511
+        private const int Small3Bytes = 4;
+        private const int Small2Bits = 12;
+        private const int Small2Bias = 1 << (Small2Bits - 1);          // 2048
+        private const int Small2Max = Small2Bias - 1;                    // 2047
+        private const int Small2Bytes = 3;
+
+        /// <summary>Smallest-three components live in [-1/sqrt2, 1/sqrt2].</summary>
+        private const float QuatHalfRange = 0.70710678f;
+
+        /// <summary>
+        /// Inputs whose squared length is below this are not directions (a Vector3.Zero
+        /// sentinel, an uninitialised value) and encode as +Y rather than as NaN.
+        /// </summary>
+        private const float UnitMinLengthSquared = 0.5f;
+        private static bool _sentinelWarned;
+
+        // ───────────────────────────── metadata ─────────────────────────────
+
+        public static int ComponentCount(SerialVariantType type, bool unitVector)
+        {
+            return type switch
+            {
+                SerialVariantType.Float => 1,
+                SerialVariantType.Vector2 => 2,
+                SerialVariantType.Vector3 => unitVector ? 2 : 3,
+                _ => 0,
+            };
+        }
+
+        /// <summary>True for the types <c>Quantize</c> is allowed on (NEBULA010).</summary>
+        public static bool IsQuantizable(SerialVariantType type)
+        {
+            return type is SerialVariantType.Float or SerialVariantType.Vector2
+                or SerialVariantType.Vector3 or SerialVariantType.Quaternion;
+        }
+
+        /// <summary>
+        /// Bits per smallest-three component for a declared step: the fewest that make the
+        /// component quantum no larger than the step, capped at <see cref="MaxQuatBits"/>.
+        /// </summary>
+        public static byte ResolveQuatBits(float step)
+        {
+            if (step <= 0f) return 0;
+            int bits = MinQuatBits;
+            while (bits < MaxQuatBits && QuatQuantum(bits) > step) bits++;
+            return (byte)bits;
+        }
+
+        /// <summary>
+        /// Code range at a bit width: one level fewer than the width allows, so the level
+        /// count is odd and ZERO is a code. A resting rotation (identity, or any axis-aligned
+        /// quarter turn) then replicates exactly instead of as a half-quantum wobble.
+        /// </summary>
+        private static uint QuatMaxCode(int bits) => (1u << bits) - 2;
+
+        /// <summary>The component quantum actually used at a bit width.</summary>
+        public static float QuatQuantum(int bits) => 2f * QuatHalfRange / QuatMaxCode(bits);
+
+        /// <summary>
+        /// Worst-case error the encoding introduces, in the units the prediction tolerance of
+        /// that type is authored in: Euclidean distance for float/Vector2/Vector3 and for unit
+        /// vectors (chord length, ~radians), radians for a quaternion (AngleTo). Bounds verified
+        /// by brute force in QuantizedCodecTests.
+        /// </summary>
+        public static float MaxError(SerialVariantType type, bool unitVector, float step)
+        {
+            switch (type)
+            {
+                case SerialVariantType.Float: return step * 0.5f;
+                case SerialVariantType.Vector2: return step * 0.5f * 1.41421356f;
+                case SerialVariantType.Vector3:
+                    // Octahedral: the square-to-sphere map's largest singular value is 3, at
+                    // the octant centres (1,1,1)/sqrt3, along the (u, w) diagonal. The worst
+                    // rounding error in the square is half a step on both axes, sqrt2 * step/2
+                    // along that diagonal, so 3 * sqrt2 / 2 = 2.12 steps on the sphere; 2.2
+                    // leaves room for float rounding. The fold is an isometry of the square,
+                    // so the lower hemisphere has the same bound.
+                    return unitVector ? step * 2.2f : step * 0.5f * 1.73205081f;
+                case SerialVariantType.Quaternion:
+                    // Three components each off by up to half a quantum, plus the
+                    // reconstructed largest component's second-order error; angle ~ 2|dq|.
+                    return 4f * QuatQuantum(ResolveQuatBits(step));
+                default: return 0f;
+            }
+        }
+
+        // ───────────────────────────── grid ─────────────────────────────
+
+        public static int Quantize(float v, float step)
+        {
+            float r = MathF.Round(v / step);
+            // Clamp in double: (float)int.MaxValue rounds up to 2^31, which is itself out of
+            // range, and an out-of-range cast is platform-defined.
+            if (r >= 2147483647.0) return int.MaxValue;
+            if (r <= -2147483648.0) return int.MinValue;
+            if (float.IsNaN(r)) return 0;
+            return (int)r;
+        }
+
+        public static float Dequantize(int q, float step) => q * step;
+
+        // ───────────────────────────── octahedral ─────────────────────────────
+
+        private static float Sgn(float f) => f >= 0f ? 1f : -1f;
+
+        /// <summary>
+        /// Octahedral projection with +Y as the fold axis, so the seams (where a direction has
+        /// two equivalent codes) lie in the -Y hemisphere, away from the "up" every direction
+        /// property rests at. Non-directions (see <see cref="UnitMinLengthSquared"/>) encode
+        /// as +Y with a one-time warning.
+        /// </summary>
+        public static void OctEncode(Vector3 v, out float u, out float w)
+        {
+            float lengthSq = v.X * v.X + v.Y * v.Y + v.Z * v.Z;
+            if (!(lengthSq >= UnitMinLengthSquared))
+            {
+                if (!_sentinelWarned)
+                {
+                    _sentinelWarned = true;
+                    GD.PushWarning($"QuantizedCodec: a UnitVector property was written with a non-direction {v}; sent as +Y. Properties that use Vector3.Zero as a sentinel must not set UnitVector.");
+                }
+                u = 0f; w = 0f;
+                return;
+            }
+            float l1 = MathF.Abs(v.X) + MathF.Abs(v.Y) + MathF.Abs(v.Z);
+            float px = v.X / l1;
+            float pz = v.Z / l1;
+            if (v.Y < 0f)
+            {
+                float fx = (1f - MathF.Abs(pz)) * Sgn(px);
+                float fz = (1f - MathF.Abs(px)) * Sgn(pz);
+                px = fx; pz = fz;
+            }
+            u = px; w = pz;
+        }
+
+        /// <summary>Inverse of <see cref="OctEncode"/>; the result is renormalised.</summary>
+        public static Vector3 OctDecode(float u, float w)
+        {
+            float y = 1f - MathF.Abs(u) - MathF.Abs(w);
+            float x = u;
+            float z = w;
+            if (y < 0f)
+            {
+                float fx = (1f - MathF.Abs(w)) * Sgn(u);
+                float fz = (1f - MathF.Abs(u)) * Sgn(w);
+                x = fx; z = fz;
+            }
+            float len = MathF.Sqrt(x * x + y * y + z * z);
+            return new Vector3(x / len, y / len, z / len);
+        }
+
+        // ───────────────────────────── value <-> codes ─────────────────────────────
+
+        /// <summary>Fills <paramref name="codes"/> (length &gt;= ComponentCount) from a value.</summary>
+        public static void Encode(in PropertyCache value, SerialVariantType type, bool unitVector, float step, Span<int> codes)
+        {
+            switch (type)
+            {
+                case SerialVariantType.Float:
+                    codes[0] = Quantize(value.FloatValue, step);
+                    break;
+                case SerialVariantType.Vector2:
+                    codes[0] = Quantize(value.Vec2Value.X, step);
+                    codes[1] = Quantize(value.Vec2Value.Y, step);
+                    break;
+                case SerialVariantType.Vector3:
+                    if (unitVector)
+                    {
+                        OctEncode(value.Vec3Value, out float u, out float w);
+                        codes[0] = Quantize(u, step);
+                        codes[1] = Quantize(w, step);
+                    }
+                    else
+                    {
+                        codes[0] = Quantize(value.Vec3Value.X, step);
+                        codes[1] = Quantize(value.Vec3Value.Y, step);
+                        codes[2] = Quantize(value.Vec3Value.Z, step);
+                    }
+                    break;
+                default:
+                    throw new NotSupportedException($"QuantizedCodec.Encode: {type} is not a grid type");
+            }
+        }
+
+        /// <summary>Writes the value the codes denote into the cache (type-tagged).</summary>
+        public static void Decode(ReadOnlySpan<int> codes, SerialVariantType type, bool unitVector, float step, ref PropertyCache cache)
+        {
+            cache.Type = type;
+            switch (type)
+            {
+                case SerialVariantType.Float:
+                    cache.FloatValue = Dequantize(codes[0], step);
+                    break;
+                case SerialVariantType.Vector2:
+                    cache.Vec2Value = new Vector2(Dequantize(codes[0], step), Dequantize(codes[1], step));
+                    break;
+                case SerialVariantType.Vector3:
+                    cache.Vec3Value = unitVector
+                        ? OctDecode(Dequantize(codes[0], step), Dequantize(codes[1], step))
+                        : new Vector3(Dequantize(codes[0], step), Dequantize(codes[1], step), Dequantize(codes[2], step));
+                    break;
+                default:
+                    throw new NotSupportedException($"QuantizedCodec.Decode: {type} is not a grid type");
+            }
+        }
+
+        /// <summary>
+        /// Replaces the value with what a client holds after receiving it: the exact float the
+        /// server's delta ring must carry for deltas against it to be exact.
+        /// </summary>
+        public static void Canonicalize(ref PropertyCache cache, SerialVariantType type, bool unitVector, float step)
+        {
+            Span<int> codes = stackalloc int[MaxComponents];
+            Encode(in cache, type, unitVector, step, codes);
+            Decode(codes, type, unitVector, step, ref cache);
+        }
+
+        // ───────────────────────────── quaternion ─────────────────────────────
+
+        /// <summary>
+        /// Smallest-three at <paramref name="bits"/> per component, largest forced positive,
+        /// components rounded (not truncated) to the grid: [index:2][a][b][c] in a uint32.
+        /// </summary>
+        public static uint PackQuat(Quaternion q, int bits)
+        {
+            float absX = MathF.Abs(q.X), absY = MathF.Abs(q.Y), absZ = MathF.Abs(q.Z), absW = MathF.Abs(q.W);
+            int maxIndex = 0;
+            float maxVal = absX;
+            if (absY > maxVal) { maxIndex = 1; maxVal = absY; }
+            if (absZ > maxVal) { maxIndex = 2; maxVal = absZ; }
+            if (absW > maxVal) { maxIndex = 3; }
+
+            float sign = maxIndex switch
+            {
+                0 => Sgn(q.X),
+                1 => Sgn(q.Y),
+                2 => Sgn(q.Z),
+                _ => Sgn(q.W),
+            };
+            float a, b, c;
+            switch (maxIndex)
+            {
+                case 0: a = q.Y * sign; b = q.Z * sign; c = q.W * sign; break;
+                case 1: a = q.X * sign; b = q.Z * sign; c = q.W * sign; break;
+                case 2: a = q.X * sign; b = q.Y * sign; c = q.W * sign; break;
+                default: a = q.X * sign; b = q.Y * sign; c = q.Z * sign; break;
+            }
+
+            uint maxCode = QuatMaxCode(bits);
+            uint ua = QuatComponentCode(a, maxCode);
+            uint ub = QuatComponentCode(b, maxCode);
+            uint uc = QuatComponentCode(c, maxCode);
+            return (uint)maxIndex | (ua << QuatIndexBits) | (ub << (QuatIndexBits + bits)) | (uc << (QuatIndexBits + 2 * bits));
+        }
+
+        private static uint QuatComponentCode(float component, uint maxCode)
+        {
+            float t = (component + QuatHalfRange) / (2f * QuatHalfRange) * maxCode;
+            float r = MathF.Round(t);
+            if (r <= 0f) return 0;
+            if (r >= maxCode) return maxCode;
+            return (uint)r;
+        }
+
+        public static Quaternion UnpackQuat(uint packed, int bits)
+        {
+            uint mask = (1u << bits) - 1;
+            uint maxCode = QuatMaxCode(bits);
+            int maxIndex = (int)(packed & ((1u << QuatIndexBits) - 1));
+            uint ua = Math.Min((packed >> QuatIndexBits) & mask, maxCode);
+            uint ub = Math.Min((packed >> (QuatIndexBits + bits)) & mask, maxCode);
+            uint uc = Math.Min((packed >> (QuatIndexBits + 2 * bits)) & mask, maxCode);
+            float scale = 2f * QuatHalfRange / maxCode;
+            float a = ua * scale - QuatHalfRange;
+            float b = ub * scale - QuatHalfRange;
+            float c = uc * scale - QuatHalfRange;
+            // Rounding can push the three components' sum of squares past 1 (the largest is
+            // then reconstructed as 0 and the result is short); renormalise so the client
+            // never holds a non-unit rotation. Deterministic: sqrt and division only.
+            float sumSq = a * a + b * b + c * c;
+            float largest = MathF.Sqrt(MathF.Max(0f, 1f - sumSq));
+            float invLen = 1f / MathF.Sqrt(sumSq + largest * largest);
+            a *= invLen; b *= invLen; c *= invLen; largest *= invLen;
+            return maxIndex switch
+            {
+                0 => new Quaternion(largest, a, b, c),
+                1 => new Quaternion(a, largest, b, c),
+                2 => new Quaternion(a, b, largest, c),
+                _ => new Quaternion(a, b, c, largest),
+            };
+        }
+
+        // ───────────────────────────── wire forms ─────────────────────────────
+
+        /// <summary>N zigzag varints.</summary>
+        public static void WriteCodes(NetBuffer buffer, ReadOnlySpan<int> codes, int count)
+        {
+            for (int i = 0; i < count; i++) NetWriter.WriteZigZagVarInt(buffer, codes[i]);
+        }
+
+        public static void ReadCodes(NetBuffer buffer, Span<int> codes, int count)
+        {
+            for (int i = 0; i < count; i++) codes[i] = NetReader.ReadZigZagVarInt(buffer);
+        }
+
+        /// <summary>
+        /// Packs the deltas into the small word for this component count if every one fits;
+        /// writes nothing and returns false otherwise (the caller then takes the full form).
+        /// </summary>
+        public static bool TryWriteSmallDelta(NetBuffer buffer, ReadOnlySpan<int> deltas, int count)
+        {
+            switch (count)
+            {
+                case 1:
+                    if (deltas[0] < short.MinValue || deltas[0] > short.MaxValue) return false;
+                    NetWriter.WriteInt16(buffer, (short)deltas[0]);
+                    return true;
+                case 2:
+                {
+                    if (!Fits(deltas[0], Small2Max) || !Fits(deltas[1], Small2Max)) return false;
+                    uint word = (uint)(deltas[0] + Small2Bias) | ((uint)(deltas[1] + Small2Bias) << Small2Bits);
+                    var span = buffer.GetWriteSpan(Small2Bytes);
+                    span[0] = (byte)word;
+                    span[1] = (byte)(word >> 8);
+                    span[2] = (byte)(word >> 16);
+                    buffer.AdvanceWrite(Small2Bytes);
+                    return true;
+                }
+                case 3:
+                {
+                    if (!Fits(deltas[0], Small3Max) || !Fits(deltas[1], Small3Max) || !Fits(deltas[2], Small3Max)) return false;
+                    uint word = (uint)(deltas[0] + Small3Bias)
+                        | ((uint)(deltas[1] + Small3Bias) << Small3Bits)
+                        | ((uint)(deltas[2] + Small3Bias) << (2 * Small3Bits));
+                    NetWriter.WriteUInt32(buffer, word);
+                    return true;
+                }
+                default:
+                    throw new NotSupportedException($"QuantizedCodec: {count} components");
+            }
+        }
+
+        private static bool Fits(int delta, int max) => delta >= -max - 1 && delta <= max;
+
+        public static void ReadSmallDelta(NetBuffer buffer, Span<int> deltas, int count)
+        {
+            switch (count)
+            {
+                case 1:
+                    deltas[0] = NetReader.ReadInt16(buffer);
+                    break;
+                case 2:
+                {
+                    var span = buffer.GetReadSpan(Small2Bytes);
+                    uint word = span[0] | ((uint)span[1] << 8) | ((uint)span[2] << 16);
+                    buffer.AdvanceRead(Small2Bytes);
+                    deltas[0] = (int)(word & (Small2Bias * 2 - 1)) - Small2Bias;
+                    deltas[1] = (int)((word >> Small2Bits) & (Small2Bias * 2 - 1)) - Small2Bias;
+                    break;
+                }
+                case 3:
+                {
+                    uint word = NetReader.ReadUInt32(buffer);
+                    deltas[0] = (int)(word & (Small3Bias * 2 - 1)) - Small3Bias;
+                    deltas[1] = (int)((word >> Small3Bits) & (Small3Bias * 2 - 1)) - Small3Bias;
+                    deltas[2] = (int)((word >> (2 * Small3Bits)) & (Small3Bias * 2 - 1)) - Small3Bias;
+                    break;
+                }
+                default:
+                    throw new NotSupportedException($"QuantizedCodec: {count} components");
+            }
+        }
+
+        /// <summary>Byte cost of the small form, for budget and census reasoning.</summary>
+        public static int SmallDeltaBytes(int count) => count switch { 1 => 2, 2 => Small2Bytes, 3 => Small3Bytes, _ => 0 };
+    }
+}

--- a/addons/Nebula/Core/Serialization/QuantizedCodec.cs.uid
+++ b/addons/Nebula/Core/Serialization/QuantizedCodec.cs.uid
@@ -1,0 +1,1 @@
+uid://f8t4mwdanh7q

--- a/addons/Nebula/Core/Serialization/Serializers/NetPropertiesSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/NetPropertiesSerializer.cs
@@ -219,6 +219,32 @@ namespace Nebula.Serialization.Serializers
         /// <summary>Pre-cached: chunk budget handed to object/custom-type serializers.</summary>
         private readonly int[] _propChunkBudget;
 
+        // ─── Wire quantization ([NetProperty(Quantize = step)]) ───
+        //
+        // Resolved once from the protocol table like IntWidth, and read by both the writer
+        // and the reader so the two can never disagree on a property's encoding. See
+        // QuantizedCodec for the wire forms and the exactness contract.
+        /// <summary>Grid step per property; 0 = not quantized (float/half encoding).</summary>
+        private readonly float[] _propQuantStep;
+        /// <summary>Smallest-three bits per component for quantized quaternions; 0 otherwise.</summary>
+        private readonly byte[] _propQuantBits;
+        /// <summary>Vector3 sent as an octahedral unit direction.</summary>
+        private readonly bool[] _propUnitVector;
+        /// <summary>Integer code count of a quantized grid property (0 for quaternions).</summary>
+        private readonly byte[] _propQuantComponents;
+        /// <summary>Bit per quantized property, for the dirty filter's fast skip.</summary>
+        private long _quantizedMask;
+        /// <summary>
+        /// Server-side dead-band state: the last grid codes that PASSED the dirty filter, per
+        /// property (MaxComponents slots each; a quaternion uses one for its packed word).
+        /// Compared against the last passed value, never the previous tick, so a slowly
+        /// creeping value accumulates until it crosses a cell instead of being filtered
+        /// forever. Unset (bit clear in <see cref="_gridSeededMask"/>) means "pass", so the
+        /// first dirty tick after a spawn or teleport always ships.
+        /// </summary>
+        private int[] _lastGridCodes;
+        private long _gridSeededMask;
+
         /// <summary>Pre-cached size in bytes of the property presence mask.</summary>
         private readonly int _byteCount;
 
@@ -323,6 +349,10 @@ namespace Nebula.Serialization.Serializers
                 _propInterestRequired = Array.Empty<long>();
                 _propIntWidth = Array.Empty<IntWidth>();
                 _propChunkBudget = Array.Empty<int>();
+                _propQuantStep = Array.Empty<float>();
+                _propQuantBits = Array.Empty<byte>();
+                _propUnitVector = Array.Empty<bool>();
+                _propQuantComponents = Array.Empty<byte>();
                 _propertiesUpdated = Array.Empty<byte>();
                 _actualMask = Array.Empty<byte>();
                 _dirtyOnlyMask = Array.Empty<byte>();
@@ -366,10 +396,15 @@ namespace Nebula.Serialization.Serializers
             _propInterestRequired = new long[_propertyCount];
             _propIntWidth = new IntWidth[_propertyCount];
             _propChunkBudget = new int[_propertyCount];
+            _propQuantStep = new float[_propertyCount];
+            _propQuantBits = new byte[_propertyCount];
+            _propUnitVector = new bool[_propertyCount];
+            _propQuantComponents = new byte[_propertyCount];
 
             for (int i = 0; i < _propertyCount; i++)
             {
                 var prop = Protocol.UnpackProperty(_cachedSceneFilePath, i);
+                ResolveQuantization(i, prop.VariantType, prop.Quantize, prop.UnitVector);
                 _propTypes[i] = prop.VariantType;
                 _propSupportsDelta[i] = SupportsDelta(prop.VariantType);
                 _propIsNodeRef[i] = prop.IsObjectProperty && Protocol.IsNodeReferenceClass(prop.ClassIndex);
@@ -557,6 +592,61 @@ namespace Nebula.Serialization.Serializers
                     // long, ulong, or an unrecognised subtype - the reader's default is Int64 too.
                     return IntWidth.Int64;
             }
+        }
+
+        /// <summary>
+        /// Fills the per-property quantization caches from the declared step. A step on a
+        /// type NEBULA010 rejects is ignored here (the generator already refused to build),
+        /// so the writer and reader can dispatch on <c>_propQuantStep &gt; 0</c> alone.
+        /// </summary>
+        private void ResolveQuantization(int propIndex, SerialVariantType type, float step, bool unitVector)
+        {
+            if (step <= 0f || !QuantizedCodec.IsQuantizable(type)) return;
+            _propQuantStep[propIndex] = step;
+            _propUnitVector[propIndex] = unitVector && type == SerialVariantType.Vector3;
+            _propQuantBits[propIndex] = type == SerialVariantType.Quaternion ? QuantizedCodec.ResolveQuatBits(step) : (byte)0;
+            _propQuantComponents[propIndex] = (byte)QuantizedCodec.ComponentCount(type, _propUnitVector[propIndex]);
+            _quantizedMask |= 1L << propIndex;
+            _lastGridCodes ??= new int[_propertyCount * QuantizedCodec.MaxComponents];
+        }
+
+        /// <summary>
+        /// Grid codes of a property's current value: the integers the wire carries. A
+        /// quaternion contributes its packed word as a single code.
+        /// </summary>
+        private void GridCodes(int propIndex, in PropertyCache value, Span<int> codes)
+        {
+            var type = _propTypes[propIndex];
+            if (type == SerialVariantType.Quaternion)
+            {
+                codes[0] = (int)QuantizedCodec.PackQuat(value.QuatValue, _propQuantBits[propIndex]);
+                return;
+            }
+            QuantizedCodec.Encode(in value, type, _propUnitVector[propIndex], _propQuantStep[propIndex], codes);
+        }
+
+        /// <summary>
+        /// The quantized dead-band: true when the property's current grid codes equal the
+        /// last codes that passed this filter, i.e. the change is invisible on the wire.
+        /// Records the codes when they differ (or on the first call), so the comparison is
+        /// always against the last SHIPPED cell.
+        /// </summary>
+        private bool GridUnchanged(int propIndex)
+        {
+            int count = _propTypes[propIndex] == SerialVariantType.Quaternion ? 1 : _propQuantComponents[propIndex];
+            Span<int> codes = stackalloc int[QuantizedCodec.MaxComponents];
+            GridCodes(propIndex, in network.CachedProperties[propIndex], codes);
+            int baseSlot = propIndex * QuantizedCodec.MaxComponents;
+            long bit = 1L << propIndex;
+            bool same = (_gridSeededMask & bit) != 0;
+            for (int k = 0; same && k < count; k++)
+            {
+                if (_lastGridCodes[baseSlot + k] != codes[k]) same = false;
+            }
+            if (same) return true;
+            for (int k = 0; k < count; k++) _lastGridCodes[baseSlot + k] = codes[k];
+            _gridSeededMask |= bit;
+            return false;
         }
 
         /// <summary>
@@ -884,7 +974,15 @@ namespace Nebula.Serialization.Serializers
         /// against a WorldRunner prepared with CreatePeerStateForTests (object properties
         /// need the Protocol serializer registry and must not be used here).
         /// </summary>
-        internal NetPropertiesSerializer(NetworkController _network, SerialVariantType[] propTypes)
+        /// <param name="intWidths">
+        /// Optional per-property integer width (Int props only; null = Int64 for all). Encoding
+        /// metadata the real ctor resolves from the protocol table is supplied here by the
+        /// test, so the reader and writer under test agree the same way they do in production.
+        /// </param>
+        /// <param name="quantizeSteps">Optional per-property grid step (0 = unquantized), as NetProperty.Quantize.</param>
+        /// <param name="unitVectors">Optional per-property UnitVector flag, as NetProperty.UnitVector.</param>
+        internal NetPropertiesSerializer(NetworkController _network, SerialVariantType[] propTypes, IntWidth[] intWidths = null,
+            float[] quantizeSteps = null, bool[] unitVectors = null)
         {
             network = _network;
             _cachedSceneFilePath = network.RawNode.SceneFilePath;
@@ -894,7 +992,10 @@ namespace Nebula.Serialization.Serializers
             _reservedMaskBytes = PresenceMask.ReservedBytes(_byteCount);
 
             _propTypes = propTypes;
+            // Mirrors the real ctor: without this, useDelta was false for every test and the
+            // delta/lossy write paths had no unit coverage at all.
             _propSupportsDelta = new bool[_propertyCount];
+            for (int i = 0; i < _propertyCount; i++) _propSupportsDelta[i] = SupportsDelta(propTypes[i]);
             _propIsNodeRef = new bool[_propertyCount];
             _propIsObject = new bool[_propertyCount];
             _propClassIndex = new int[_propertyCount];
@@ -904,8 +1005,23 @@ namespace Nebula.Serialization.Serializers
             // Visible on every interest layer, like a property with no [NetInterest].
             for (int i = 0; i < _propertyCount; i++) _propInterestMask[i] = -1L;
             _propInterestRequired = new long[_propertyCount];
-            _propIntWidth = new IntWidth[_propertyCount];
+            _propIntWidth = intWidths ?? new IntWidth[_propertyCount];
+            if (_propIntWidth.Length != _propertyCount)
+            {
+                throw new ArgumentException($"intWidths length {_propIntWidth.Length} != property count {_propertyCount}", nameof(intWidths));
+            }
             _propChunkBudget = new int[_propertyCount];
+            _propQuantStep = new float[_propertyCount];
+            _propQuantBits = new byte[_propertyCount];
+            _propUnitVector = new bool[_propertyCount];
+            _propQuantComponents = new byte[_propertyCount];
+            for (int i = 0; i < _propertyCount; i++)
+            {
+                ResolveQuantization(i,
+                    propTypes[i],
+                    quantizeSteps != null ? quantizeSteps[i] : 0f,
+                    unitVectors != null && unitVectors[i]);
+            }
 
             _propertiesUpdated = new byte[_byteCount];
             _actualMask = new byte[_byteCount];
@@ -988,6 +1104,22 @@ namespace Nebula.Serialization.Serializers
             if (_appliedRing == null) return false;
             ref var entry = ref _appliedRing[tick % SNAPSHOT_RING_SIZE];
             return entry.Values != null && entry.Tick == tick;
+        }
+
+        /// <summary>Test seam (client): the applied value recorded for a property at a tick.</summary>
+        internal PropertyCache AppliedValueForTests(Tick tick, int propIndex)
+        {
+            ref var entry = ref _appliedRing[tick % SNAPSHOT_RING_SIZE];
+            if (entry.Values == null || entry.Tick != tick) throw new InvalidOperationException($"no applied entry at tick {tick}");
+            return entry.Values[propIndex];
+        }
+
+        /// <summary>Test seam (server): the delta-ring value (canonical for quantized props) at a tick.</summary>
+        internal PropertyCache RingValueForTests(Tick tick, int propIndex)
+        {
+            ref var entry = ref _tickValueRing[tick % SNAPSHOT_RING_SIZE];
+            if (entry.Values == null || entry.Tick != tick) throw new InvalidOperationException($"no ring entry at tick {tick}");
+            return entry.Values[propIndex];
         }
 
         private Data Deserialize(NetBuffer buffer, Tick currentTick, out bool discarded)
@@ -1090,18 +1222,6 @@ namespace Nebula.Serialization.Serializers
 
                     var propertyIndex = propertyByteIndex * BitConstants.BitsInByte + propertyBit;
 
-                    var prop = Protocol.UnpackProperty(_cachedSceneFilePath, propertyIndex);
-                    if (string.IsNullOrEmpty(prop.Name))
-                    {
-                        continue;
-                    }
-
-                    // Skip IsObjectProperty (INetSerializable) - handled in Pass 2
-                    if (prop.IsObjectProperty)
-                    {
-                        continue;
-                    }
-
                     // Bounded by _propertyCount, not CachedProperties.Length: the latter is a
                     // fixed 64 regardless of how many properties this scene declares, so it
                     // would admit indices that have no entry in the pre-cached metadata arrays.
@@ -1110,33 +1230,43 @@ namespace Nebula.Serialization.Serializers
                         Debugger.Instance.Log(Debugger.DebugLevel.ERROR, $"[NetPropertiesSerializer.Deserialize] propertyIndex {propertyIndex} >= property count {_propertyCount}! Skipping property.");
                         continue;
                     }
+
+                    // Metadata comes from the constructor's pre-cached arrays, the same ones
+                    // the writer dispatches on (and the only ones the Protocol-free test
+                    // constructor fills), never from a per-property registry lookup here.
+                    // Skip IsObjectProperty (INetSerializable) - handled in Pass 2
+                    if (_propIsObject[propertyIndex])
+                    {
+                        continue;
+                    }
+                    var propType = _propTypes[propertyIndex];
                     ref var existingCache = ref network.CachedProperties[propertyIndex];
 
                     int propStartPos = buffer.ReadPosition;
                     var cache = new PropertyCache();
 
-                    if (prop.VariantType == SerialVariantType.Nil)
+                    if (propType == SerialVariantType.Nil)
                     {
-                        Debugger.Instance.Log(Debugger.DebugLevel.ERROR, $"Property {prop.NodePath}.{prop.Name} has VariantType.Nil, cannot deserialize");
+                        Debugger.Instance.Log(Debugger.DebugLevel.ERROR, $"Property {PropertyNameForLog(propertyIndex)} has VariantType.Nil, cannot deserialize");
                         continue;
                     }
 
                     // INetValue types with Object VariantType (like UUID) need special handling
                     // They're written with delta encoding wrapper (Absolute flag byte first) but use custom deserializer
-                    if (prop.VariantType == SerialVariantType.Object)
+                    if (propType == SerialVariantType.Object)
                     {
                         // Read the delta encoding flag byte (will always be Absolute for Object types since they don't support delta)
                         var flags = (DeltaEncodingFlags)NetReader.ReadByte(buffer);
                         if (flags != DeltaEncodingFlags.Absolute)
                         {
-                            Debugger.Instance.Log(Debugger.DebugLevel.ERROR, $"Expected Absolute encoding for INetValue Object type {prop.NodePath}.{prop.Name}, got {flags}");
+                            Debugger.Instance.Log(Debugger.DebugLevel.ERROR, $"Expected Absolute encoding for INetValue Object type {PropertyNameForLog(propertyIndex)}, got {flags}");
                         }
 
                         // Use the deserializer for the value type
-                        var deserializer = Protocol.GetDeserializer(prop.ClassIndex);
+                        var deserializer = Protocol.GetDeserializer(_propClassIndex[propertyIndex]);
                         if (deserializer == null)
                         {
-                            Debugger.Instance.Log(Debugger.DebugLevel.ERROR, $"No deserializer found for INetValue {prop.NodePath}.{prop.Name}");
+                            Debugger.Instance.Log(Debugger.DebugLevel.ERROR, $"No deserializer found for INetValue {PropertyNameForLog(propertyIndex)}");
                             continue;
                         }
                         var existingValue = existingCache.RefValue;
@@ -1148,19 +1278,18 @@ namespace Nebula.Serialization.Serializers
                         // Read the value, applying deltas against the baseline snapshot.
                         // With no baseline (absolute payload or discard mode) a scratch
                         // default is passed - deltas can't occur in a well-formed absolute
-                        // payload. The absolute path still needs the raw subtype string,
-                        // since NetReader.ReadAbsoluteValue is shared with other call sites.
+                        // payload.
                         if (baselineValues != null)
                         {
-                            ReadDeltaOrAbsolute(buffer, prop.VariantType, _propIntWidth[propertyIndex], prop.Metadata.TypeIdentifier, ref baselineValues[propertyIndex], ref cache);
+                            ReadDeltaOrAbsolute(buffer, propertyIndex, propType, _propIntWidth[propertyIndex], ref baselineValues[propertyIndex], ref cache);
                         }
                         else
                         {
-                            ReadDeltaOrAbsolute(buffer, prop.VariantType, _propIntWidth[propertyIndex], prop.Metadata.TypeIdentifier, ref noBaseline, ref cache);
+                            ReadDeltaOrAbsolute(buffer, propertyIndex, propType, _propIntWidth[propertyIndex], ref noBaseline, ref cache);
                         }
                     }
 
-                    if (TraceWire) Debugger.Instance.Log($"[Props.R] idx={propertyIndex} '{prop.NodePath}.{prop.Name}' type={prop.VariantType} bytes={buffer.ReadPosition - propStartPos} end={buffer.ReadPosition}");
+                    if (TraceWire) Debugger.Instance.Log($"[Props.R] idx={propertyIndex} '{PropertyNameForLog(propertyIndex)}' type={propType} bytes={buffer.ReadPosition - propStartPos} end={buffer.ReadPosition}");
 
                     if (!discardPayload)
                     {
@@ -1183,13 +1312,18 @@ namespace Nebula.Serialization.Serializers
 
                     var propertyIndex = propertyByteIndex * BitConstants.BitsInByte + propertyBit;
 
+                    // Only process IsObjectProperty (INetSerializable) in this pass; the
+                    // registry lookup is deferred until the bit is known to be one (the
+                    // Protocol-free test ctor has no registry entry to unpack).
+                    if (propertyIndex >= _propertyCount || !_propIsObject[propertyIndex])
+                    {
+                        continue;
+                    }
                     var prop = Protocol.UnpackProperty(_cachedSceneFilePath, propertyIndex);
                     if (string.IsNullOrEmpty(prop.Name))
                     {
                         continue;
                     }
-
-                    // Only process IsObjectProperty (INetSerializable) in this pass
                     if (!prop.IsObjectProperty)
                     {
                         continue;
@@ -1279,10 +1413,18 @@ namespace Nebula.Serialization.Serializers
         /// declared baseline tick), never against the running value.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void ReadDeltaOrAbsolute(NetBuffer buffer, SerialVariantType type, IntWidth intWidth, string subtype, ref PropertyCache baseline, ref PropertyCache cache)
+        private void ReadDeltaOrAbsolute(NetBuffer buffer, int propIndex, SerialVariantType type, IntWidth intWidth, ref PropertyCache baseline, ref PropertyCache cache)
         {
             var flags = (DeltaEncodingFlags)NetReader.ReadByte(buffer);
             cache.Type = type;
+
+            // Quantized properties have their own forms for every flag value, decided by
+            // the protocol table, so this must come before the QuatCompressed shortcut.
+            if (_propQuantStep[propIndex] > 0f)
+            {
+                ReadQuantized(buffer, flags, propIndex, type, ref baseline, ref cache);
+                return;
+            }
 
             // Check for quaternion compressed encoding
             if ((flags & DeltaEncodingFlags.QuatCompressed) != 0)
@@ -1298,41 +1440,118 @@ namespace Nebula.Serialization.Serializers
             {
                 case DeltaEncodingFlags.Absolute:
                     // Full absolute value
-                    ReadAbsoluteValue(buffer, type, subtype, ref cache);
+                    ReadAbsoluteValue(buffer, type, intWidth, ref cache);
                     break;
 
                 case DeltaEncodingFlags.DeltaSmall:
                     // Small delta (half-float/short encoding)
-                    ReadSmallDelta(buffer, type, intWidth, subtype, ref baseline, ref cache);
+                    ReadSmallDelta(buffer, type, intWidth, ref baseline, ref cache);
                     break;
 
                 case DeltaEncodingFlags.DeltaFull:
                     // Full delta (same type as property)
-                    ReadFullDelta(buffer, type, intWidth, subtype, ref baseline, ref cache);
+                    ReadFullDelta(buffer, type, intWidth, ref baseline, ref cache);
                     break;
 
                 default:
                     Debugger.Instance.Log(Debugger.DebugLevel.ERROR, $"Unknown delta encoding flag: {flags}");
-                    ReadAbsoluteValue(buffer, type, subtype, ref cache);
+                    ReadAbsoluteValue(buffer, type, intWidth, ref cache);
                     break;
             }
         }
 
         /// <summary>
-        /// Reads an absolute property value (no delta).
-        /// Delegates to NetReader.ReadAbsoluteValue for reuse.
+        /// Mirror of the writer's quantized paths (WriteAbsolute / WriteDelta): a packed
+        /// quaternion word, or N grid codes absolute / as a small packed delta / as varint
+        /// deltas applied to Quantize(baseline). The stored value is Dequantize(codes),
+        /// which is exactly what the server's canonical ring holds for this tick.
+        /// </summary>
+        private void ReadQuantized(NetBuffer buffer, DeltaEncodingFlags flags, int propIndex, SerialVariantType type, ref PropertyCache baseline, ref PropertyCache cache)
+        {
+            if (type == SerialVariantType.Quaternion)
+            {
+                if ((flags & DeltaEncodingFlags.QuatCompressed) == 0)
+                {
+                    throw new InvalidOperationException($"quantized quaternion property {propIndex} arrived without QuatCompressed (flags={flags})");
+                }
+                cache.QuatValue = QuantizedCodec.UnpackQuat(NetReader.ReadUInt32(buffer), _propQuantBits[propIndex]);
+                return;
+            }
+
+            int count = _propQuantComponents[propIndex];
+            bool unit = _propUnitVector[propIndex];
+            float step = _propQuantStep[propIndex];
+            Span<int> codes = stackalloc int[QuantizedCodec.MaxComponents];
+            switch (flags & (DeltaEncodingFlags)0x7F)
+            {
+                case DeltaEncodingFlags.Absolute:
+                    QuantizedCodec.ReadCodes(buffer, codes, count);
+                    break;
+                case DeltaEncodingFlags.DeltaSmall:
+                case DeltaEncodingFlags.DeltaFull:
+                {
+                    Span<int> deltas = stackalloc int[QuantizedCodec.MaxComponents];
+                    if ((flags & (DeltaEncodingFlags)0x7F) == DeltaEncodingFlags.DeltaSmall)
+                        QuantizedCodec.ReadSmallDelta(buffer, deltas, count);
+                    else
+                        QuantizedCodec.ReadCodes(buffer, deltas, count);
+                    QuantizedCodec.Encode(in baseline, type, unit, step, codes);
+                    for (int k = 0; k < count; k++) codes[k] += deltas[k];
+                    break;
+                }
+                default:
+                    throw new InvalidOperationException($"unknown delta encoding flag {flags} on quantized property {propIndex}");
+            }
+            QuantizedCodec.Decode(codes, type, unit, step, ref cache);
+        }
+
+        /// <summary>Property name for a log line; the registry may not know a test scene.</summary>
+        private string PropertyNameForLog(int propIndex)
+            => Protocol.TryUnpackProperty(_cachedSceneFilePath, propIndex, out var prop) ? $"{prop.NodePath}.{prop.Name}" : $"#{propIndex}";
+
+        /// <summary>
+        /// Reads an absolute property value (no delta). Int properties read at the width the
+        /// constructor resolved (the same <see cref="IntWidth"/> WriteAbsoluteValue writes at),
+        /// so reader and writer share one source of truth; everything else delegates to
+        /// NetReader.ReadAbsoluteValue.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void ReadAbsoluteValue(NetBuffer buffer, SerialVariantType type, string subtype, ref PropertyCache cache)
+        private static void ReadAbsoluteValue(NetBuffer buffer, SerialVariantType type, IntWidth intWidth, ref PropertyCache cache)
         {
-            NetReader.ReadAbsoluteValue(buffer, type, subtype, ref cache);
+            if (type != SerialVariantType.Int)
+            {
+                NetReader.ReadAbsoluteValue(buffer, type, null, ref cache);
+                return;
+            }
+            cache.LongValue = 0;
+            switch (intWidth)
+            {
+                case IntWidth.Byte:
+                    cache.ByteValue = NetReader.ReadByte(buffer);
+                    break;
+                case IntWidth.Int16:
+                    cache.IntValue = NetReader.ReadInt16(buffer);
+                    break;
+                case IntWidth.UInt16:
+                    cache.IntValue = NetReader.ReadUInt16(buffer);
+                    break;
+                case IntWidth.Int32:
+                    cache.IntValue = NetReader.ReadInt32(buffer);
+                    break;
+                case IntWidth.UInt32:
+                    cache.IntValue = (int)NetReader.ReadUInt32(buffer);
+                    break;
+                default:
+                    cache.LongValue = NetReader.ReadInt64(buffer);
+                    break;
+            }
         }
 
         /// <summary>
         /// Reads a small delta (half-float/short) and applies it to the baseline value.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void ReadSmallDelta(NetBuffer buffer, SerialVariantType type, IntWidth intWidth, string subtype, ref PropertyCache baseline, ref PropertyCache cache)
+        private static void ReadSmallDelta(NetBuffer buffer, SerialVariantType type, IntWidth intWidth, ref PropertyCache baseline, ref PropertyCache cache)
         {
             switch (type)
             {
@@ -1379,7 +1598,7 @@ namespace Nebula.Serialization.Serializers
                 default:
                     // Fallback to absolute for unsupported small delta types
                     Debugger.Instance.Log(Debugger.DebugLevel.WARN, $"Small delta not supported for type {type}, reading absolute");
-                    ReadAbsoluteValue(buffer, type, subtype, ref cache);
+                    ReadAbsoluteValue(buffer, type, intWidth, ref cache);
                     break;
             }
         }
@@ -1388,7 +1607,7 @@ namespace Nebula.Serialization.Serializers
         /// Reads a full delta and applies it to the baseline value.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void ReadFullDelta(NetBuffer buffer, SerialVariantType type, IntWidth intWidth, string subtype, ref PropertyCache baseline, ref PropertyCache cache)
+        private static void ReadFullDelta(NetBuffer buffer, SerialVariantType type, IntWidth intWidth, ref PropertyCache baseline, ref PropertyCache cache)
         {
             switch (type)
             {
@@ -1439,7 +1658,7 @@ namespace Nebula.Serialization.Serializers
                 default:
                     // Fallback to absolute for unsupported delta types
                     Debugger.Instance.Log(Debugger.DebugLevel.WARN, $"Full delta not supported for type {type}, reading absolute");
-                    ReadAbsoluteValue(buffer, type, subtype, ref cache);
+                    ReadAbsoluteValue(buffer, type, intWidth, ref cache);
                     break;
             }
         }
@@ -1478,8 +1697,7 @@ namespace Nebula.Serialization.Serializers
             var serializer = Protocol.GetSerializer(_propClassIndex[propIndex]);
             if (serializer == null)
             {
-                var missing = Protocol.UnpackProperty(_cachedSceneFilePath, propIndex);
-                Debugger.Instance.Log(Debugger.DebugLevel.ERROR, $"No serializer found for {missing.NodePath}.{missing.Name}");
+                Debugger.Instance.Log(Debugger.DebugLevel.ERROR, $"No serializer found for {PropertyNameForLog(propIndex)}");
                 return;
             }
 
@@ -1513,12 +1731,43 @@ namespace Nebula.Serialization.Serializers
             // computed against entries of this ring at their respective acked ticks.
             if (_propertyCount > 0 && (NetRunner.Instance.IsServer || ForceRingCaptureForTests) && network.CurrentWorld != null)
             {
+                // Quantized dead-band: a dirty property whose value still encodes to the
+                // grid cell last shipped has nothing to say on the wire. Dropped from the
+                // tick's dirty set here, before any peer is visited, so it is memo-safe and
+                // lets a jittering-but-still node reach Settled. _nonDefaultMask above has
+                // already recorded the write for initial sync. Per-peer props never get
+                // here (NEBULA010 refuses Quantize with PerPeerState).
+                long quantizedDirty = processingDirtyMask & _quantizedMask;
+                while (quantizedDirty != 0)
+                {
+                    int propIndex = System.Numerics.BitOperations.TrailingZeroCount(quantizedDirty);
+                    quantizedDirty &= quantizedDirty - 1;
+                    if (!_propIsPerPeer[propIndex] && GridUnchanged(propIndex))
+                    {
+                        processingDirtyMask &= ~(1L << propIndex);
+                    }
+                }
+
                 _tickValueRing ??= new TickSnapshot[SNAPSHOT_RING_SIZE];
                 Tick tick = network.CurrentWorld.CurrentTick;
                 ref var entry = ref _tickValueRing[tick % SNAPSHOT_RING_SIZE];
                 entry.Values ??= new PropertyCache[_propertyCount];
                 Array.Copy(network.CachedProperties, entry.Values, _propertyCount);
                 entry.Tick = tick;
+
+                // Baseline canonicalisation: a quantized grid property's ring slot holds the
+                // value the CLIENT holds after decoding it, so both sides compute the
+                // delta's Quantize(baseline) from bit-identical floats. Gameplay keeps
+                // reading full precision from CachedProperties; only the delta ring is
+                // canonical. Quaternions are skipped: they never delta (SupportsDelta).
+                long canonical = _quantizedMask;
+                while (canonical != 0)
+                {
+                    int propIndex = System.Numerics.BitOperations.TrailingZeroCount(canonical);
+                    canonical &= canonical - 1;
+                    if (_propQuantComponents[propIndex] == 0) continue;
+                    QuantizedCodec.Canonicalize(ref entry.Values[propIndex], _propTypes[propIndex], _propUnitVector[propIndex], _propQuantStep[propIndex]);
+                }
             }
         }
 
@@ -2369,9 +2618,8 @@ namespace Nebula.Serialization.Serializers
                         }
                         catch (Exception ex)
                         {
-                            var prop = Protocol.UnpackProperty(_cachedSceneFilePath, propIndex);
                             Debugger.Instance.Log(Debugger.DebugLevel.ERROR,
-                                $"Error serializing property {prop.NodePath}.{prop.Name}: {ex.InnerException?.Message ?? ex.Message}");
+                                $"Error serializing property {PropertyNameForLog(propIndex)}: {ex.InnerException?.Message ?? ex.Message}");
                             // Clear the bit AND rewind - stray partial bytes would desync the
                             // whole stream for every property and node after this one
                             actualMask[i] &= (byte)~(1 << j);
@@ -2525,9 +2773,8 @@ namespace Nebula.Serialization.Serializers
                 }
                 catch (Exception ex)
                 {
-                    var prop = Protocol.UnpackProperty(_cachedSceneFilePath, propIndex);
                     Debugger.Instance.Log(Debugger.DebugLevel.ERROR,
-                        $"Error serializing object property {prop.NodePath}.{prop.Name}: {ex.InnerException?.Message ?? ex.Message}");
+                        $"Error serializing object property {PropertyNameForLog(propIndex)}: {ex.InnerException?.Message ?? ex.Message}");
                     // Rewind on error
                     buffer.WritePosition = startPos;
                     BankNodeRefIfMasked(propIndex);
@@ -2757,6 +3004,23 @@ namespace Nebula.Serialization.Serializers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteAbsolute(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer, int propIndex, ref PropertyCache current)
         {
+            if (_propQuantStep[propIndex] > 0f)
+            {
+                if (_propTypes[propIndex] == SerialVariantType.Quaternion)
+                {
+                    NetWriter.WriteByte(buffer, (byte)(DeltaEncodingFlags.Absolute | DeltaEncodingFlags.QuatCompressed));
+                    NetWriter.WriteUInt32(buffer, QuantizedCodec.PackQuat(current.QuatValue, _propQuantBits[propIndex]));
+                }
+                else
+                {
+                    Span<int> codes = stackalloc int[QuantizedCodec.MaxComponents];
+                    GridCodes(propIndex, in current, codes);
+                    NetWriter.WriteByte(buffer, (byte)DeltaEncodingFlags.Absolute);
+                    QuantizedCodec.WriteCodes(buffer, codes, _propQuantComponents[propIndex]);
+                }
+                return;
+            }
+
             // Quaternion: use smallest-three compression
             if (_propTypes[propIndex] == SerialVariantType.Quaternion)
             {
@@ -2803,6 +3067,30 @@ namespace Nebula.Serialization.Serializers
             ref PropertyCache baseline)
         {
             var type = _propTypes[propIndex];
+
+            if (_propQuantStep[propIndex] > 0f)
+            {
+                // Integer step-count delta against the canonical ring value: exact by
+                // construction (the client adds it to Quantize(its identical baseline)),
+                // so never lossy. Small packed word when every component fits, else the
+                // varint form - TryWriteSmallDelta writes nothing when it declines.
+                int count = _propQuantComponents[propIndex];
+                Span<int> codes = stackalloc int[QuantizedCodec.MaxComponents];
+                Span<int> baseCodes = stackalloc int[QuantizedCodec.MaxComponents];
+                GridCodes(propIndex, in current, codes);
+                GridCodes(propIndex, in baseline, baseCodes);
+                for (int k = 0; k < count; k++) codes[k] -= baseCodes[k];
+
+                int flagPos = buffer.WritePosition;
+                NetWriter.WriteByte(buffer, (byte)DeltaEncodingFlags.DeltaSmall);
+                if (!QuantizedCodec.TryWriteSmallDelta(buffer, codes, count))
+                {
+                    buffer.WritePosition = flagPos;
+                    NetWriter.WriteByte(buffer, (byte)DeltaEncodingFlags.DeltaFull);
+                    QuantizedCodec.WriteCodes(buffer, codes, count);
+                }
+                return false;
+            }
 
             switch (type)
             {

--- a/addons/Nebula/Generator/NetPropertyGenerator.cs
+++ b/addons/Nebula/Generator/NetPropertyGenerator.cs
@@ -68,6 +68,15 @@ public class NetPropertyGenerator : IIncrementalGenerator
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    // Diagnostic for invalid wire quantization declarations
+    private static readonly DiagnosticDescriptor QuantizeInvalidDiagnostic = new(
+        id: "NEBULA010",
+        title: "Invalid quantization declaration",
+        messageFormat: "Property '{0}': {1}",
+        category: "Nebula",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
@@ -93,6 +102,8 @@ public class NetPropertyGenerator : IIncrementalGenerator
         float interpolateSpeed = 15f;
         bool predicted = false;
         bool perPeerState = false;
+        float quantize = 0f;
+        bool unitVector = false;
 
         foreach (var attr in propertySymbol.GetAttributes())
         {
@@ -117,6 +128,12 @@ public class NetPropertyGenerator : IIncrementalGenerator
                             break;
                         case "PerPeerState" when namedArg.Value.Value is bool b4:
                             perPeerState = b4;
+                            break;
+                        case "Quantize" when namedArg.Value.Value is float q:
+                            quantize = q;
+                            break;
+                        case "UnitVector" when namedArg.Value.Value is bool b5:
+                            unitVector = b5;
                             break;
                     }
                 }
@@ -207,7 +224,9 @@ public class NetPropertyGenerator : IIncrementalGenerator
             implementsINetSerializable,
             perPeerState,
             isPartial,
-            GetAccessibilityKeyword(propertySymbol.DeclaredAccessibility));
+            GetAccessibilityKeyword(propertySymbol.DeclaredAccessibility),
+            quantize,
+            unitVector);
     }
 
     private static string GetAccessibilityKeyword(Accessibility accessibility) => accessibility switch
@@ -363,6 +382,37 @@ public class NetPropertyGenerator : IIncrementalGenerator
     /// <summary>
     /// Returns true if the type is a NetArray type.
     /// </summary>
+    /// <summary>
+    /// The NEBULA010 rule set. Null when the declaration is valid (including the default of
+    /// no quantization at all).
+    /// </summary>
+    private static string? QuantizeProblem(PropertyInfo prop)
+    {
+        var normalizedType = prop.PropertyType.Replace("Godot.", "");
+        bool quantizable = normalizedType is "float" or "System.Single" or "Vector2" or "Vector3" or "Quaternion";
+        if (prop.Quantize < 0f)
+        {
+            return "Quantize must be >= 0";
+        }
+        if (prop.Quantize > 0f && !quantizable)
+        {
+            return $"Quantize is only supported on float, Vector2, Vector3 and Quaternion properties, not '{prop.PropertyType}'";
+        }
+        if (prop.Quantize > 0f && prop.IsPerPeer)
+        {
+            return "Quantize cannot be combined with PerPeerState (per-peer values bypass the shared grid baseline)";
+        }
+        if (prop.UnitVector && normalizedType != "Vector3")
+        {
+            return $"UnitVector is only supported on Vector3 properties, not '{prop.PropertyType}'";
+        }
+        if (prop.UnitVector && prop.Quantize <= 0f)
+        {
+            return "UnitVector requires Quantize > 0 (the octahedral step)";
+        }
+        return null;
+    }
+
     private static bool IsNetArrayType(string propertyType)
     {
         return propertyType.StartsWith("Nebula.Serialization.NetArray<");
@@ -585,6 +635,23 @@ public class NetPropertyGenerator : IIncrementalGenerator
                         prop.PropertyLocation,
                         prop.PropertyName,
                         prop.PropertyType));
+                }
+            }
+
+            // Report diagnostics for invalid quantization declarations (NEBULA010). The
+            // serializer dispatches on "Quantize > 0" per property, so anything that reaches
+            // the protocol table with a step on an unsupported type would misalign the wire.
+            foreach (var prop in propList)
+            {
+                if (prop!.PropertyLocation == null) continue;
+                string? problem = QuantizeProblem(prop);
+                if (problem != null)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        QuantizeInvalidDiagnostic,
+                        prop.PropertyLocation,
+                        prop.PropertyName,
+                        problem));
                 }
             }
 
@@ -1303,5 +1370,8 @@ public class NetPropertyGenerator : IIncrementalGenerator
         // Per-peer fields
         bool IsPerPeer,
         bool IsPartial,
-        string Accessibility);
+        string Accessibility,
+        // Wire quantization (see NetProperty.Quantize / UnitVector)
+        float Quantize,
+        bool UnitVector);
 }

--- a/addons/Nebula/Generator/ProtocolBuilder/CodeEmitter.cs
+++ b/addons/Nebula/Generator/ProtocolBuilder/CodeEmitter.cs
@@ -154,6 +154,10 @@ namespace Nebula.Generators
                         Mix(prop.IsPerPeer ? "1" : "0");
                         Mix(prop.IsEnum ? "1" : "0");
                         Mix(prop.ChunkBudget.ToString(CultureInfo.InvariantCulture));
+                        // Quantization is wire layout (integer step counts instead of floats),
+                        // unlike the client-local NotifyOnChange/Interpolate/Predicted flags.
+                        Mix(prop.Quantize.ToString("R", CultureInfo.InvariantCulture));
+                        Mix(prop.UnitVector ? "1" : "0");
                     }
                 }
 
@@ -450,7 +454,9 @@ namespace Nebula.Generators
             sb.AppendLine($"{indent}    {prop.Predicted.ToString().ToLowerInvariant()},");
             sb.AppendLine($"{indent}    {prop.ChunkBudget},");
             sb.AppendLine($"{indent}    {prop.IsObjectProperty.ToString().ToLowerInvariant()},");
-            sb.AppendLine($"{indent}    {prop.IsPerPeer.ToString().ToLowerInvariant()}),");
+            sb.AppendLine($"{indent}    {prop.IsPerPeer.ToString().ToLowerInvariant()},");
+            sb.AppendLine($"{indent}    {prop.Quantize.ToString("R", CultureInfo.InvariantCulture)}f,");
+            sb.AppendLine($"{indent}    {prop.UnitVector.ToString().ToLowerInvariant()}),");
         }
 
         private static void EmitPropertyWithIntKey(StringBuilder sb, int key, PropertyData prop, string indent)
@@ -484,7 +490,9 @@ namespace Nebula.Generators
             sb.AppendLine($"{indent}    {prop.Predicted.ToString().ToLowerInvariant()},");
             sb.AppendLine($"{indent}    {prop.ChunkBudget},");
             sb.AppendLine($"{indent}    {prop.IsObjectProperty.ToString().ToLowerInvariant()},");
-            sb.AppendLine($"{indent}    {prop.IsPerPeer.ToString().ToLowerInvariant()}),");
+            sb.AppendLine($"{indent}    {prop.IsPerPeer.ToString().ToLowerInvariant()},");
+            sb.AppendLine($"{indent}    {prop.Quantize.ToString("R", CultureInfo.InvariantCulture)}f,");
+            sb.AppendLine($"{indent}    {prop.UnitVector.ToString().ToLowerInvariant()}),");
         }
 
         private static void EmitFunctionsMap(StringBuilder sb, ProtocolData data)

--- a/addons/Nebula/Generator/ProtocolBuilder/Models.cs
+++ b/addons/Nebula/Generator/ProtocolBuilder/Models.cs
@@ -77,6 +77,10 @@ namespace Nebula.Generators
         /// When true, this property stores per-peer values (different value for each connected peer).
         /// </summary>
         public bool IsPerPeer { get; set; } = false;
+        /// <summary>Wire grid step; 0 = not quantized. Part of the protocol hash.</summary>
+        public float Quantize { get; set; } = 0f;
+        /// <summary>Vector3 sent as an octahedral unit direction. Part of the protocol hash.</summary>
+        public bool UnitVector { get; set; } = false;
     }
 
     internal sealed class FunctionData

--- a/addons/Nebula/Generator/ProtocolBuilder/ProtocolGenerator.cs
+++ b/addons/Nebula/Generator/ProtocolBuilder/ProtocolGenerator.cs
@@ -533,7 +533,9 @@ namespace Nebula.Generators
                                 Predicted = prop.Value.Predicted,
                                 ChunkBudget = prop.Value.ChunkBudget,
                                 IsObjectProperty = prop.Value.IsObjectProperty,
-                                IsPerPeer = prop.Value.IsPerPeer
+                                IsPerPeer = prop.Value.IsPerPeer,
+                                Quantize = prop.Value.Quantize,
+                                UnitVector = prop.Value.UnitVector
                             };
                         }
                     }
@@ -627,7 +629,9 @@ namespace Nebula.Generators
                             Predicted = prop.Predicted,
                             ChunkBudget = prop.ChunkBudget,
                             IsObjectProperty = isObjectProperty,
-                            IsPerPeer = prop.IsPerPeer
+                            IsPerPeer = prop.IsPerPeer,
+                            Quantize = prop.Quantize,
+                            UnitVector = prop.UnitVector
                         };
                     }
                 }

--- a/addons/Nebula/Generator/ProtocolBuilder/TypeAnalyzer.cs
+++ b/addons/Nebula/Generator/ProtocolBuilder/TypeAnalyzer.cs
@@ -42,6 +42,10 @@ namespace Nebula.Generators
             /// When true, this property stores per-peer values (different value for each connected peer).
             /// </summary>
             public bool IsPerPeer { get; init; } = false;
+            /// <summary>Wire grid step; 0 = not quantized. See NetProperty.Quantize.</summary>
+            public float Quantize { get; init; } = 0f;
+            /// <summary>Vector3 sent as an octahedral unit direction. See NetProperty.UnitVector.</summary>
+            public bool UnitVector { get; init; } = false;
         }
 
         public sealed class NetFunctionInfo
@@ -362,6 +366,8 @@ namespace Nebula.Generators
                         Predicted = GetNamedArgument(netPropAttr, "Predicted", false),
                         ChunkBudget = GetNamedArgument(netPropAttr, "ChunkBudget", 256),
                         IsPerPeer = GetNamedArgument(netPropAttr, "PerPeerState", false),
+                        Quantize = GetNamedArgument(netPropAttr, "Quantize", 0f),
+                        UnitVector = GetNamedArgument(netPropAttr, "UnitVector", false),
                     };
                 }
 

--- a/addons/Nebula/Generator/Shared/ProtocolTypes.cs
+++ b/addons/Nebula/Generator/Shared/ProtocolTypes.cs
@@ -141,6 +141,16 @@ namespace Nebula.Serialization
         /// The serializer will look up the value for the specific peer being exported to.
         /// </summary>
         public readonly bool IsPerPeer;
+        /// <summary>
+        /// Wire grid step in the property's units; 0 = float/half encoding. Values travel
+        /// as integer step counts (see QuantizedCodec). Part of the protocol hash.
+        /// </summary>
+        public readonly float Quantize;
+        /// <summary>
+        /// Vector3 sent as an octahedral unit direction; Quantize is the step in octahedral
+        /// units. Part of the protocol hash.
+        /// </summary>
+        public readonly bool UnitVector;
 
         public ProtocolNetProperty(
             string nodePath,
@@ -158,7 +168,9 @@ namespace Nebula.Serialization
             bool predicted = false,
             int chunkBudget = 256,
             bool isObjectProperty = false,
-            bool isPerPeer = false)
+            bool isPerPeer = false,
+            float quantize = 0f,
+            bool unitVector = false)
         {
             NodePath = nodePath;
             Name = name;
@@ -176,6 +188,8 @@ namespace Nebula.Serialization
             ChunkBudget = chunkBudget;
             IsObjectProperty = isObjectProperty;
             IsPerPeer = isPerPeer;
+            Quantize = quantize;
+            UnitVector = unitVector;
         }
     }
 

--- a/addons/Nebula/Testing/Unit/PropsMemoTests.cs
+++ b/addons/Nebula/Testing/Unit/PropsMemoTests.cs
@@ -36,6 +36,9 @@ public class PropsMemoTests
         /// lookup. Worlds and serializers stay per-fixture; only the identity is shared.
         /// </summary>
         public Fixture(bool memoOn, UUID sharedPeerId, params SerialVariantType[] propTypes)
+            : this(memoOn, sharedPeerId, propTypes, null) { }
+
+        public Fixture(bool memoOn, UUID sharedPeerId, SerialVariantType[] propTypes, float[] quantizeSteps)
         {
             World = new WorldRunner();
             Peer = default;
@@ -50,7 +53,7 @@ public class PropsMemoTests
             {
                 Node.Network.CachedProperties[i] = new PropertyCache { Type = propTypes[i], IntValue = 40 + i };
             }
-            Serializer = new NetPropertiesSerializer(Node.Network, propTypes)
+            Serializer = new NetPropertiesSerializer(Node.Network, propTypes, null, quantizeSteps)
             {
                 MemoOverrideForTests = memoOn,
                 ForceRingCaptureForTests = true,
@@ -268,11 +271,29 @@ public class PropsMemoTests
         RunOnOffEquivalence(types);
     }
 
-    private static void RunOnOffEquivalence(params SerialVariantType[] types)
+    // 7c. The wide matrix again with every float QUANTIZED (0.01 step): the integer delta
+    //     forms, the canonical ring and the dead-band filter are all node-level, so the
+    //     memo signature must still describe the bytes completely.
+    [NebulaUnitTest]
+    public void OnOffEquivalence_RandomizedSchedules_QuantizedMembers()
+    {
+        var types = new SerialVariantType[24];
+        var steps = new float[24];
+        for (int i = 0; i < types.Length; i++)
+        {
+            types[i] = (i % 3 == 1) ? SerialVariantType.Float : SerialVariantType.Int;
+            steps[i] = (i % 3 == 1) ? 0.01f : 0f;
+        }
+        RunOnOffEquivalence(types, steps);
+    }
+
+    private static void RunOnOffEquivalence(params SerialVariantType[] types) => RunOnOffEquivalence(types, null);
+
+    private static void RunOnOffEquivalence(SerialVariantType[] types, float[] quantizeSteps)
     {
         var peerId = UUID.NewUUID();
-        using var on = new Fixture(memoOn: true, peerId, types);
-        using var off = new Fixture(memoOn: false, peerId, types);
+        using var on = new Fixture(memoOn: true, peerId, types, quantizeSteps);
+        using var off = new Fixture(memoOn: false, peerId, types, quantizeSteps);
 
         long allProps = types.Length >= 64 ? -1L : (1L << types.Length) - 1;
         var rng = new Random(1234);   // fixed seed: failures must reproduce
@@ -307,14 +328,20 @@ public class PropsMemoTests
                 f.Serializer.Begin();
             }
 
+            // The second export of a peer in one tick is NOT a repeat of the first: a
+            // settle absolute in the first export clears the peer's lossy bit, so the
+            // second one legitimately omits that property. So the memo-served second
+            // export is compared against a slow-path second export from identical
+            // state, not against the first.
             var bufOnA = Buffer(); on.Serializer.Export(on.World, on.Peer, bufOnA, int.MaxValue);
             var bufOnB = Buffer(); on.Serializer.Export(on.World, on.Peer, bufOnB, int.MaxValue);
-            var bufOff = Buffer(); off.Serializer.Export(off.World, off.Peer, bufOff, int.MaxValue);
+            var bufOffA = Buffer(); off.Serializer.Export(off.World, off.Peer, bufOffA, int.MaxValue);
+            var bufOffB = Buffer(); off.Serializer.Export(off.World, off.Peer, bufOffB, int.MaxValue);
 
-            Assert.True(bufOnA.WrittenSpan.SequenceEqual(bufOff.WrittenSpan),
+            Assert.True(bufOnA.WrittenSpan.SequenceEqual(bufOffA.WrittenSpan),
                 $"tick {tick}: memo-on first export diverged from memo-off");
-            Assert.True(bufOnA.WrittenSpan.SequenceEqual(bufOnB.WrittenSpan),
-                $"tick {tick}: memo-served bytes diverged from fresh encode");
+            Assert.True(bufOnB.WrittenSpan.SequenceEqual(bufOffB.WrittenSpan),
+                $"tick {tick}: memo-served bytes diverged from fresh encode of the same state");
 
             foreach (var f in new[] { on, off })
             {

--- a/addons/Nebula/Testing/Unit/PropsQuantizedWireTests.cs
+++ b/addons/Nebula/Testing/Unit/PropsQuantizedWireTests.cs
@@ -1,0 +1,317 @@
+using System;
+using Godot;
+using Nebula;
+using Nebula.Serialization;
+using Nebula.Serialization.Serializers;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// Quantized properties end to end through the props serializer: a server fixture exports
+/// and a client fixture (same metadata, Protocol-free ctor) deserializes, so every claim
+/// the encoding makes - section sizes, exact deltas, no lossy settle, the server-side
+/// dead-band, the 30-delta refresh - is asserted on real bytes and real applied values.
+///
+/// Delta encoding needs an acked baseline and a send the previous tick, so the scripts
+/// here run the full per-tick cycle: Begin, Export, client Deserialize, CommitExport,
+/// Acknowledge.
+/// </summary>
+[NebulaUnitTest]
+public class PropsQuantizedWireTests
+{
+    private const int UnitDir = 0;     // Vector3, UnitVector, step 2e-5 (LocalSurfaceDirection-like)
+    private const int Height = 1;      // Float, step 0.01 (TerrainHeight-like)
+    private const int Position = 2;    // Vector3, step 0.01 (NetPosition-like)
+    private const int Rotation = 3;    // Quaternion, step 0.002 (NetRotation-like)
+
+    private const float UnitStep = 0.00002f;
+    private const float GridStep = 0.01f;
+    private const float QuatStep = 0.002f;
+
+    private const int MaskBytes = 1;
+    private const int AgeBytes = 1;
+    private const int FlagBytes = 1;
+
+    private sealed class Fixture : IDisposable
+    {
+        public WorldRunner World;
+        public NetPeer Peer;
+        public UUID PeerId;
+        public NetNode ServerNode;
+        public NetPropertiesSerializer Server;
+        public NetNode ClientNode;
+        public NetPropertiesSerializer Client;
+
+        public Fixture()
+        {
+            var types = new[] { SerialVariantType.Vector3, SerialVariantType.Float, SerialVariantType.Vector3, SerialVariantType.Quaternion };
+            var steps = new[] { UnitStep, GridStep, GridStep, QuatStep };
+            var units = new[] { true, false, false, false };
+
+            World = new WorldRunner();
+            Peer = default;
+            PeerId = UUID.NewUUID();
+            NetRunner.Instance.PeerIds[0] = PeerId;
+            World.CreatePeerStateForTests(Peer, PeerId);
+
+            ServerNode = new NetNode();
+            ServerNode.Network.InterestLayers[PeerId] = 1;
+            ServerNode.Network.CurrentWorld = World;
+            ServerNode.Network.CachedProperties[UnitDir] = new PropertyCache { Type = SerialVariantType.Vector3, Vec3Value = Vector3.Up };
+            ServerNode.Network.CachedProperties[Height] = new PropertyCache { Type = SerialVariantType.Float, FloatValue = 601.23f };
+            ServerNode.Network.CachedProperties[Position] = new PropertyCache { Type = SerialVariantType.Vector3, Vec3Value = new Vector3(1200f, -35.5f, 4000f) };
+            ServerNode.Network.CachedProperties[Rotation] = new PropertyCache { Type = SerialVariantType.Quaternion, QuatValue = Quaternion.Identity };
+            Server = new NetPropertiesSerializer(ServerNode.Network, types, null, steps, units)
+            {
+                ForceRingCaptureForTests = true,
+            };
+            World.SetClientSpawnState(ServerNode.Network.NetId, Peer, WorldRunner.ClientSpawnState.Spawning);
+
+            ClientNode = new NetNode();
+            Client = new NetPropertiesSerializer(ClientNode.Network, types, null, steps, units);
+        }
+
+        public void Set(int prop, Vector3 v)
+        {
+            var c = ServerNode.Network.CachedProperties[prop]; c.Vec3Value = v; ServerNode.Network.CachedProperties[prop] = c;
+        }
+        public void Set(int prop, float f)
+        {
+            var c = ServerNode.Network.CachedProperties[prop]; c.FloatValue = f; ServerNode.Network.CachedProperties[prop] = c;
+        }
+        public void Set(int prop, Quaternion q)
+        {
+            var c = ServerNode.Network.CachedProperties[prop]; c.QuatValue = q; ServerNode.Network.CachedProperties[prop] = c;
+        }
+
+        /// <summary>
+        /// One full tick: mark the given props dirty, export, deliver to the client, commit
+        /// and ack. Returns the section bytes (empty when nothing was exported).
+        /// </summary>
+        public NetBuffer Tick(int tick, params int[] dirty)
+        {
+            long mask = 0;
+            foreach (var i in dirty) mask |= 1L << i;
+            World.CurrentTick = tick;
+            ServerNode.Network.DirtyMask = mask;
+            Server.Begin();
+            var buf = new NetBuffer(256, usePool: false);
+            var result = Server.Export(World, Peer, buf, int.MaxValue);
+            if (result != ExportResult.None)
+            {
+                buf.ResetRead();
+                Assert.True(Client.DeserializeForTests(buf, tick), $"tick {tick}: client discarded the payload");
+                Server.CommitExport(World, Peer, tick);
+                Server.Acknowledge(World, Peer, tick);
+            }
+            return buf;
+        }
+
+        public void Dispose()
+        {
+            NetRunner.Instance.PeerIds.Remove(0);
+            ServerNode.Free();
+            ClientNode.Free();
+            World.Free();
+        }
+    }
+
+    private static DeltaEncodingFlags Flag(NetBuffer buf) => (DeltaEncodingFlags)buf.WrittenSpan[MaskBytes + AgeBytes];
+
+    private static bool BitEqual(Vector3 a, Vector3 b)
+        => BitConverter.SingleToInt32Bits(a.X) == BitConverter.SingleToInt32Bits(b.X)
+        && BitConverter.SingleToInt32Bits(a.Y) == BitConverter.SingleToInt32Bits(b.Y)
+        && BitConverter.SingleToInt32Bits(a.Z) == BitConverter.SingleToInt32Bits(b.Z);
+
+    // 1. Section sizes match the plan's table, absolute then delta, per type.
+    [NebulaUnitTest]
+    public void SectionSizes_MatchTheTable()
+    {
+        using var f = new Fixture();
+        const int Overhead = MaskBytes + AgeBytes + FlagBytes;
+
+        // Unit vector at rest (+Y): octahedral (0, 0) -> two 1-byte varints.
+        var b = f.Tick(1, UnitDir);
+        Assert.Equal(DeltaEncodingFlags.Absolute, Flag(b));
+        Assert.Equal(Overhead + 2, b.Length);
+        // One walking tick (0.0017 rad): 2x12-bit small delta in 3 bytes.
+        f.Set(UnitDir, new Vector3(MathF.Sin(0.0017f), MathF.Cos(0.0017f), 0f));
+        b = f.Tick(2, UnitDir);
+        Assert.Equal(DeltaEncodingFlags.DeltaSmall, Flag(b));
+        Assert.Equal(Overhead + 3, b.Length);
+
+        // Float 601.23 at 0.01: code 60123 -> 3-byte varint; +0.05 -> int16 delta.
+        b = f.Tick(3, Height);
+        Assert.Equal(DeltaEncodingFlags.Absolute, Flag(b));
+        Assert.Equal(Overhead + 3, b.Length);
+        f.Set(Height, 601.28f);
+        b = f.Tick(4, Height);
+        Assert.Equal(DeltaEncodingFlags.DeltaSmall, Flag(b));
+        Assert.Equal(Overhead + 2, b.Length);
+
+        // Position (1200, -35.5, 4000) at 0.01: varints of 3, 2 and 3 bytes (codes 120000,
+        // -3550, 400000); a ship tick at 100 u/s (3.33 u) is 333 steps -> 3x10-bit in a
+        // uint32; at 200 u/s (667 steps) it overflows the small form and falls back to 3
+        // varints (2 bytes each).
+        b = f.Tick(5, Position);
+        Assert.Equal(DeltaEncodingFlags.Absolute, Flag(b));
+        Assert.Equal(Overhead + 3 + 2 + 3, b.Length);
+        f.Set(Position, new Vector3(1203.33f, -35.5f, 4000f));
+        b = f.Tick(6, Position);
+        Assert.Equal(DeltaEncodingFlags.DeltaSmall, Flag(b));
+        Assert.Equal(Overhead + 4, b.Length);
+        f.Set(Position, new Vector3(1210f, -35.5f, 4000f));
+        b = f.Tick(7, Position);
+        Assert.Equal(DeltaEncodingFlags.DeltaFull, Flag(b));
+        Assert.Equal(Overhead + 2 + 1 + 1, b.Length);
+
+        // Quaternion: packed uint32, absolute only, QuatCompressed flag.
+        f.Set(Rotation, new Quaternion(Vector3.Up, 0.3f));
+        b = f.Tick(8, Rotation);
+        Assert.Equal(DeltaEncodingFlags.Absolute | DeltaEncodingFlags.QuatCompressed, Flag(b));
+        Assert.Equal(Overhead + 4, b.Length);
+        f.Set(Rotation, new Quaternion(Vector3.Up, 0.35f));
+        b = f.Tick(9, Rotation);
+        Assert.Equal(DeltaEncodingFlags.Absolute | DeltaEncodingFlags.QuatCompressed, Flag(b));
+        Assert.Equal(Overhead + 4, b.Length);
+    }
+
+    // 2. The walking script: 60 ticks of a direction advancing 0.0017 rad and a height
+    //    creeping, with acks. The client's applied value equals the server's canonical
+    //    ring value BIT FOR BIT every tick, no lossy bit is ever set, the absolutes are
+    //    exactly the initial one and the 30-delta refresh, and the node settles the moment
+    //    the walk stops - no settle absolute.
+    [NebulaUnitTest]
+    public void Walk_ClientMatchesServerCanonicalExactly_NoLossy_RefreshFires_NoSettle()
+    {
+        using var f = new Fixture();
+        int absolutes = 0, smalls = 0;
+        for (int tick = 1; tick <= 60; tick++)
+        {
+            float theta = 0.0017f * tick;
+            f.Set(UnitDir, new Vector3(MathF.Sin(theta) * 0.8f, MathF.Cos(theta), MathF.Sin(theta) * 0.6f).Normalized());
+            f.Set(Height, 601.23f + 0.031f * tick);
+            var b = f.Tick(tick, UnitDir, Height);
+            Assert.True(b.Length > 0, $"tick {tick}: nothing exported");
+
+            // Flag of the first written prop (UnitDir, index 0).
+            var flag = Flag(b);
+            if (flag == DeltaEncodingFlags.Absolute) absolutes++;
+            else if (flag == DeltaEncodingFlags.DeltaSmall) smalls++;
+            else Assert.Fail($"tick {tick}: unexpected flag {flag}");
+
+            Assert.Equal(0, f.Server.LossyByteForTests(f.PeerId, 0));
+
+            var serverDir = f.Server.RingValueForTests(tick, UnitDir).Vec3Value;
+            var clientDir = f.Client.AppliedValueForTests(tick, UnitDir).Vec3Value;
+            Assert.True(BitEqual(serverDir, clientDir), $"tick {tick}: client {clientDir} != server canonical {serverDir}");
+            float serverH = f.Server.RingValueForTests(tick, Height).FloatValue;
+            float clientH = f.Client.AppliedValueForTests(tick, Height).FloatValue;
+            Assert.Equal(BitConverter.SingleToInt32Bits(serverH), BitConverter.SingleToInt32Bits(clientH));
+
+            // The canonical value is within the declared resolution of the true one.
+            Assert.True((serverDir - f.ServerNode.Network.CachedProperties[UnitDir].Vec3Value).Length()
+                <= QuantizedCodec.MaxError(SerialVariantType.Vector3, true, UnitStep));
+        }
+        // Tick 1 absolute, ticks 2..31 deltas (chain 30), tick 32 refresh absolute, then deltas.
+        Assert.Equal(2, absolutes);
+        Assert.Equal(58, smalls);
+
+        // Walk stops: nothing dirty -> nothing exported, and the peer is settled with no
+        // lossy residue to settle.
+        var quiet = f.Tick(61);
+        Assert.Equal(0, quiet.Length);
+        Assert.Equal(0, f.Server.LossyByteForTests(f.PeerId, 0));
+        Assert.True(f.Server.SettledForTests(f.PeerId), "peer should be settled: exact deltas leave nothing owed");
+    }
+
+    // 3. The dead-band. Sub-step jitter never ships; a creep of 0.15 steps per tick is
+    //    filtered until the accumulated drift crosses a cell boundary (tick 4), and the
+    //    filter compares against the last SHIPPED cell, not the previous tick.
+    [NebulaUnitTest]
+    public void DirtyFilter_JitterNeverShips_CreepShipsOnCellCross()
+    {
+        using var f = new Fixture();
+        f.Set(Height, 1.0f);
+        Assert.True(f.Tick(1, Height).Length > 0);
+
+        // Jitter within +-0.2 step around the shipped cell.
+        float[] jitter = { 1.002f, 0.998f, 1.001f, 0.9985f, 1.0f };
+        for (int i = 0; i < jitter.Length; i++)
+        {
+            f.Set(Height, jitter[i]);
+            Assert.Equal(0, f.Tick(2 + i, Height).Length);
+            Assert.False(f.Server.SettledForTests(f.PeerId) == false && f.Server.PendingDirtyByteForTests(f.PeerId, 0) != 0,
+                "a filtered change must leave nothing pending");
+        }
+
+        // Creep: 1.0015, 1.003, 1.0045 stay in cell 100; 1.006 rounds to 101 and ships.
+        float[] creep = { 1.0015f, 1.003f, 1.0045f, 1.006f };
+        for (int i = 0; i < creep.Length; i++)
+        {
+            f.Set(Height, creep[i]);
+            var b = f.Tick(10 + i, Height);
+            if (i < 3) Assert.Equal(0, b.Length);
+            else
+            {
+                Assert.True(b.Length > 0, "creep must ship once it crosses a cell");
+                Assert.Equal(1.01f, f.Client.AppliedValueForTests(13, Height).FloatValue, 5);
+            }
+        }
+
+        // The filter is server-only state; the same value written again after a ship is
+        // filtered, but a real change is not.
+        f.Set(Height, 1.0102f);
+        Assert.Equal(0, f.Tick(20, Height).Length);
+        f.Set(Height, 1.02f);
+        Assert.True(f.Tick(21, Height).Length > 0);
+    }
+
+    // 4. A seam-crossing direction (the -Y hemisphere fold) through the real serializer:
+    //    the full-varint delta escape lands the client on the canonical value exactly.
+    [NebulaUnitTest]
+    public void SeamCrossing_ThroughSerializer_IsExact()
+    {
+        using var f = new Fixture();
+        bool sawFull = false;
+        for (int tick = 1; tick <= 200; tick++)
+        {
+            float t = tick / 200f * MathF.PI * 2f;
+            f.Set(UnitDir, new Vector3(MathF.Cos(t), -0.6f + 0.3f * MathF.Sin(3 * t), MathF.Sin(t)).Normalized());
+            var b = f.Tick(tick, UnitDir);
+            Assert.True(b.Length > 0);
+            if (Flag(b) == DeltaEncodingFlags.DeltaFull) sawFull = true;
+            Assert.True(BitEqual(f.Server.RingValueForTests(tick, UnitDir).Vec3Value, f.Client.AppliedValueForTests(tick, UnitDir).Vec3Value), $"tick {tick}");
+            Assert.Equal(0, f.Server.LossyByteForTests(f.PeerId, 0));
+        }
+        Assert.True(sawFull, "the sweep never took the full-delta seam escape");
+    }
+
+    // 5. Position deltas are exact too, including the small->full fallback at speed, and
+    //    a quaternion round-trips within its declared error.
+    [NebulaUnitTest]
+    public void PositionAndRotation_ClientValuesExactAndBounded()
+    {
+        using var f = new Fixture();
+        var pos = new Vector3(1200f, -35.5f, 4000f);
+        for (int tick = 1; tick <= 40; tick++)
+        {
+            pos += new Vector3(tick < 20 ? 3.33f : 6.67f, 0.01f * tick, -1.5f);
+            f.Set(Position, pos);
+            f.Set(Rotation, new Quaternion(new Vector3(0.3f, 1f, 0.2f).Normalized(), 0.05f * tick));
+            var b = f.Tick(tick, Position, Rotation);
+            Assert.True(b.Length > 0);
+
+            var sp = f.Server.RingValueForTests(tick, Position).Vec3Value;
+            var cp = f.Client.AppliedValueForTests(tick, Position).Vec3Value;
+            Assert.True(BitEqual(sp, cp), $"tick {tick}: {cp} != {sp}");
+            Assert.True((sp - pos).Length() <= QuantizedCodec.MaxError(SerialVariantType.Vector3, false, GridStep) * 1.001f);
+
+            var cq = f.Client.AppliedValueForTests(tick, Rotation).QuatValue;
+            var sq = f.ServerNode.Network.CachedProperties[Rotation].QuatValue;
+            Assert.True(sq.AngleTo(cq) <= QuantizedCodec.MaxError(SerialVariantType.Quaternion, false, QuatStep), $"tick {tick}: rotation error {sq.AngleTo(cq)}");
+        }
+        Assert.Equal(0, f.Server.LossyByteForTests(f.PeerId, 0));
+    }
+}

--- a/addons/Nebula/Testing/Unit/PropsQuantizedWireTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/PropsQuantizedWireTests.cs.uid
@@ -1,0 +1,1 @@
+uid://tydv1vfpq3xw

--- a/addons/Nebula/Testing/Unit/QuantizedCodecTests.cs
+++ b/addons/Nebula/Testing/Unit/QuantizedCodecTests.cs
@@ -1,0 +1,335 @@
+using System;
+using Godot;
+using Nebula;
+using Nebula.Serialization;
+using Nebula.Serialization.Serializers;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// The quantized wire codec as pure value logic. The invariant deltas rest on is NOT
+/// "re-encoding a decoded value gives the same code" (false on the octahedral seams) but
+/// "decoding is a deterministic function of the codes, and canonicalising is idempotent" -
+/// so the seam tests assert bit-equality of decoded floats, never code equality.
+/// </summary>
+[NebulaUnitTest]
+public class QuantizedCodecTests
+{
+    private static NetBuffer Buffer() => new(64, usePool: false);
+
+    // ───────────── varints ─────────────
+
+    [NebulaUnitTest]
+    public void ZigZagVarInt_RoundTrips_WithExpectedWidths()
+    {
+        (int value, int bytes)[] cases =
+        {
+            (0, 1), (1, 1), (-1, 1), (63, 1), (-64, 1), (64, 2), (-65, 2),
+            (8191, 2), (-8192, 2), (8192, 3), (30000, 3), (-30000, 3),
+            (1 << 20, 4), (int.MaxValue, 5), (int.MinValue, 5),
+        };
+        foreach (var (value, bytes) in cases)
+        {
+            var buf = Buffer();
+            NetWriter.WriteZigZagVarInt(buf, value);
+            Assert.Equal(bytes, buf.Length);
+            buf.ResetRead();
+            Assert.Equal(value, NetReader.ReadZigZagVarInt(buf));
+        }
+    }
+
+    // ───────────── grid ─────────────
+
+    [NebulaUnitTest]
+    public void Grid_CodeRoundTrip_IsExact_AcrossStepsAndMagnitudes()
+    {
+        float[] steps = { 0.01f, 0.001f, 0.002f, 0.0005f, 0.00002f, 1f };
+        float[] magnitudes = { 0f, 0.37f, 1f, 12.5f, 601f, 6000f, 25000f };
+        foreach (var step in steps)
+        {
+            foreach (var m in magnitudes)
+            {
+                // The declared resolution only holds inside the float32 round-robust range.
+                if (m >= 0.5f * step * (1 << 24)) continue;
+                foreach (var v in new[] { m, -m, m + step * 0.49f, m - step * 0.49f })
+                {
+                    int q = QuantizedCodec.Quantize(v, step);
+                    float d = QuantizedCodec.Dequantize(q, step);
+                    Assert.Equal(q, QuantizedCodec.Quantize(d, step));
+                    // The input itself is a float32: near 25,000 its ulp (~0.002) is a
+                    // real part of the distance to the grid point.
+                    float ulp = MathF.BitIncrement(MathF.Abs(v)) - MathF.Abs(v);
+                    Assert.True(MathF.Abs(d - v) <= step * 0.5f + ulp + step * 1e-3f, $"v={v} step={step} d={d}");
+                }
+            }
+        }
+    }
+
+    [NebulaUnitTest]
+    public void Grid_OutOfRange_ClampsInsteadOfPlatformCast()
+    {
+        Assert.Equal(int.MaxValue, QuantizedCodec.Quantize(1e30f, 0.01f));
+        Assert.Equal(int.MinValue, QuantizedCodec.Quantize(-1e30f, 0.01f));
+        Assert.Equal(0, QuantizedCodec.Quantize(float.NaN, 0.01f));
+    }
+
+    // ───────────── octahedral ─────────────
+
+    private static Vector3[] SphereSample()
+    {
+        // Dense deterministic sample plus every axis, face edge midpoint and corner: the
+        // seams and the eight octant corners (where all three components are equal) are
+        // where a fold can round two ways.
+        var rng = new Random(77);
+        var list = new System.Collections.Generic.List<Vector3>();
+        for (int i = 0; i < 4000; i++)
+        {
+            var v = new Vector3((float)rng.NextDouble() * 2 - 1, (float)rng.NextDouble() * 2 - 1, (float)rng.NextDouble() * 2 - 1);
+            if (v.LengthSquared() < 1e-3f) continue;
+            list.Add(v.Normalized());
+        }
+        float s = 1f / MathF.Sqrt(3f);
+        float h = 1f / MathF.Sqrt(2f);
+        foreach (var sx in new[] { -1f, 1f })
+        foreach (var sy in new[] { -1f, 1f })
+        foreach (var sz in new[] { -1f, 1f })
+        {
+            list.Add(new Vector3(sx * s, sy * s, sz * s));
+            list.Add(new Vector3(sx * h, sy * h, 0));
+            list.Add(new Vector3(sx * h, 0, sz * h));
+            list.Add(new Vector3(0, sy * h, sz * h));
+        }
+        list.Add(Vector3.Up); list.Add(Vector3.Down); list.Add(Vector3.Left);
+        list.Add(Vector3.Right); list.Add(Vector3.Forward); list.Add(Vector3.Back);
+        // Points just off the octant centres, where the map stretches most: the worst
+        // rounding sits half a step along the (u, w) diagonal from a grid point.
+        for (int i = 0; i < 64; i++)
+        {
+            float du = 0.00002f * (i / 8 - 4) / 4f;
+            float dw = 0.00002f * (i % 8 - 4) / 4f;
+            list.Add(QuantizedCodec.OctDecode(1f / 3f + du, 1f / 3f + dw));
+            list.Add(QuantizedCodec.OctDecode(-1f / 3f + du, 1f / 3f + dw));
+            list.Add(QuantizedCodec.OctDecode(2f / 3f + du, 2f / 3f + dw)); // lower hemisphere
+        }
+        return list.ToArray();
+    }
+
+    [NebulaUnitTest]
+    public void Octahedral_DecodeEncode_WithinMaxError_AndCanonicalIsIdempotent()
+    {
+        const float step = 0.00002f;
+        float maxError = QuantizedCodec.MaxError(SerialVariantType.Vector3, unitVector: true, step);
+        float worst = 0f;
+        Span<int> codes = stackalloc int[2];
+        foreach (var v in SphereSample())
+        {
+            var cache = new PropertyCache { Type = SerialVariantType.Vector3, Vec3Value = v };
+            QuantizedCodec.Encode(in cache, SerialVariantType.Vector3, true, step, codes);
+            var once = cache;
+            QuantizedCodec.Decode(codes, SerialVariantType.Vector3, true, step, ref once);
+
+            float err = (once.Vec3Value - v).Length();
+            worst = MathF.Max(worst, err);
+            Assert.True(err <= maxError, $"{v}: error {err} > MaxError {maxError}");
+            Assert.True(MathF.Abs(once.Vec3Value.Length() - 1f) < 1e-5f, "decode must renormalise");
+
+            // The contract: canonicalising an already-canonical value is a bit-identical no-op,
+            // even where the re-encoded CODE differs (seams, corners).
+            var twice = once;
+            QuantizedCodec.Canonicalize(ref twice, SerialVariantType.Vector3, true, step);
+            Assert.True(BitEqual(twice.Vec3Value, once.Vec3Value), $"{v}: canonical not idempotent");
+        }
+        Assert.True(worst > maxError * 0.2f, $"MaxError {maxError} is absurdly loose against observed {worst}");
+    }
+
+    [NebulaUnitTest]
+    public void Octahedral_SeamCrossing_DeltaChainIsExact()
+    {
+        // A direction sweeping through the -Y hemisphere across both fold seams (x=0 and
+        // z=0 with y<0), replicated as a chain of integer deltas the way the serializer does
+        // it: server canonical ring on one side, client applied value on the other. The
+        // client must land on the server's canonical value bit for bit every tick, whether
+        // or not the seam made the re-encoded baseline code differ from the one sent.
+        const float step = 0.00002f;
+        Span<int> serverCodes = stackalloc int[2];
+        Span<int> baseCodes = stackalloc int[2];
+        Span<int> clientCodes = stackalloc int[2];
+
+        PropertyCache serverRing = default, clientApplied = default;
+        bool haveBaseline = false;
+        int fullDeltas = 0;
+        for (int i = 0; i <= 400; i++)
+        {
+            float t = (i / 400f) * MathF.PI * 2f;
+            // Circle in the plane tilted so it dips below y=0 and crosses x=0 and z=0 there.
+            var v = new Vector3(MathF.Cos(t), -0.6f + 0.3f * MathF.Sin(3 * t), MathF.Sin(t)).Normalized();
+            var current = new PropertyCache { Type = SerialVariantType.Vector3, Vec3Value = v };
+            QuantizedCodec.Encode(in current, SerialVariantType.Vector3, true, step, serverCodes);
+
+            if (!haveBaseline)
+            {
+                // Absolute: client stores Dequantize(codes).
+                clientApplied = current;
+                QuantizedCodec.Decode(serverCodes, SerialVariantType.Vector3, true, step, ref clientApplied);
+                haveBaseline = true;
+            }
+            else
+            {
+                // Server: delta = Q(current) - Q(ring).
+                QuantizedCodec.Encode(in serverRing, SerialVariantType.Vector3, true, step, baseCodes);
+                int d0 = serverCodes[0] - baseCodes[0];
+                int d1 = serverCodes[1] - baseCodes[1];
+                var buf = Buffer();
+                Span<int> wd = stackalloc int[] { d0, d1 };
+                bool small = QuantizedCodec.TryWriteSmallDelta(buf, wd, 2);
+                if (!small)
+                {
+                    fullDeltas++;
+                    QuantizedCodec.WriteCodes(buf, wd, 2);
+                }
+                buf.ResetRead();
+                Span<int> rd = stackalloc int[2];
+                if (small) QuantizedCodec.ReadSmallDelta(buf, rd, 2);
+                else QuantizedCodec.ReadCodes(buf, rd, 2);
+                Assert.Equal(d0, rd[0]); Assert.Equal(d1, rd[1]);
+
+                // Client: Q(applied) + delta, store Dequantize.
+                QuantizedCodec.Encode(in clientApplied, SerialVariantType.Vector3, true, step, clientCodes);
+                clientCodes[0] += rd[0];
+                clientCodes[1] += rd[1];
+                QuantizedCodec.Decode(clientCodes, SerialVariantType.Vector3, true, step, ref clientApplied);
+            }
+
+            // Server ring for next tick: canonical value.
+            serverRing = current;
+            QuantizedCodec.Canonicalize(ref serverRing, SerialVariantType.Vector3, true, step);
+            Assert.True(BitEqual(clientApplied.Vec3Value, serverRing.Vec3Value), $"tick {i}: client {clientApplied.Vec3Value} != server canonical {serverRing.Vec3Value}");
+        }
+        Assert.True(fullDeltas > 0, "sweep never crossed a seam - the test is not exercising the fold");
+    }
+
+    [NebulaUnitTest]
+    public void Octahedral_Sentinel_EncodesAsUp()
+    {
+        QuantizedCodec.OctEncode(Vector3.Zero, out float u, out float w);
+        Assert.Equal(0f, u); Assert.Equal(0f, w);
+        Assert.Equal(Vector3.Up, QuantizedCodec.OctDecode(0f, 0f));
+    }
+
+    // ───────────── small-delta forms ─────────────
+
+    [NebulaUnitTest]
+    public void SmallDelta_RangeBoundaries_FallBackToFull()
+    {
+        (int count, int max)[] shapes = { (1, short.MaxValue), (2, 2047), (3, 511) };
+        foreach (var (count, max) in shapes)
+        {
+            Span<int> d = stackalloc int[3];
+            Span<int> rd = stackalloc int[3];
+            foreach (var edge in new[] { max, -max - 1, 0, 1, -1 })
+            {
+                for (int i = 0; i < count; i++) d[i] = i == 0 ? edge : -edge / 2;
+                var buf = Buffer();
+                Assert.True(QuantizedCodec.TryWriteSmallDelta(buf, d, count), $"N={count} edge {edge} should fit");
+                Assert.Equal(QuantizedCodec.SmallDeltaBytes(count), buf.Length);
+                buf.ResetRead();
+                QuantizedCodec.ReadSmallDelta(buf, rd, count);
+                for (int i = 0; i < count; i++) Assert.Equal(d[i], rd[i]);
+            }
+            foreach (var over in new[] { max + 1, -max - 2 })
+            {
+                for (int i = 0; i < count; i++) d[i] = 0;
+                d[count - 1] = over;
+                var buf = Buffer();
+                Assert.False(QuantizedCodec.TryWriteSmallDelta(buf, d, count), $"N={count} {over} must not fit");
+                Assert.Equal(0, buf.Length);
+                QuantizedCodec.WriteCodes(buf, d, count);
+                buf.ResetRead();
+                QuantizedCodec.ReadCodes(buf, rd, count);
+                for (int i = 0; i < count; i++) Assert.Equal(d[i], rd[i]);
+            }
+        }
+    }
+
+    // ───────────── quaternion ─────────────
+
+    [NebulaUnitTest]
+    public void Quaternion_BitsResolveFromStep()
+    {
+        Assert.Equal(10, QuantizedCodec.ResolveQuatBits(0.002f));
+        Assert.Equal(10, QuantizedCodec.ResolveQuatBits(0.0001f)); // capped
+        Assert.Equal(8, QuantizedCodec.ResolveQuatBits(0.006f));
+        Assert.Equal(0, QuantizedCodec.ResolveQuatBits(0f));
+        for (int bits = 2; bits <= 10; bits++)
+        {
+            Assert.True(QuantizedCodec.QuatQuantum(bits) <= QuantizedCodec.QuatQuantum(bits - 1 < 2 ? 2 : bits - 1), $"quantum not monotone at {bits}");
+        }
+    }
+
+    [NebulaUnitTest]
+    public void Quaternion_PackUnpack_WithinMaxError_PreservesHemisphere()
+    {
+        var rng = new Random(5);
+        foreach (int bits in new[] { 8, 9, 10 })
+        {
+            float step = QuantizedCodec.QuatQuantum(bits);
+            Assert.Equal(bits, QuantizedCodec.ResolveQuatBits(step));
+            float maxError = QuantizedCodec.MaxError(SerialVariantType.Quaternion, false, step);
+            float worst = 0f;
+            for (int i = 0; i < 3000; i++)
+            {
+                var axis = new Vector3((float)rng.NextDouble() * 2 - 1, (float)rng.NextDouble() * 2 - 1, (float)rng.NextDouble() * 2 - 1).Normalized();
+                var q = new Quaternion(axis, (float)(rng.NextDouble() * Math.PI * 2 - Math.PI));
+                if (i % 7 == 0) q = -q; // the other sign of the same rotation
+                var back = QuantizedCodec.UnpackQuat(QuantizedCodec.PackQuat(q, bits), bits);
+                Assert.True(MathF.Abs(back.Length() - 1f) < 1e-4f, $"bits={bits} not unit: {back.Length()}");
+                float angle = q.AngleTo(back);
+                worst = MathF.Max(worst, angle);
+                Assert.True(angle <= maxError, $"bits={bits} {q}: angle {angle} > MaxError {maxError}");
+                // Largest component positive on the wire: q and -q decode identically.
+                var backNeg = QuantizedCodec.UnpackQuat(QuantizedCodec.PackQuat(-q, bits), bits);
+                Assert.True(back == backNeg, $"bits={bits} q/-q decoded differently: {back} vs {backNeg}");
+            }
+            Assert.True(worst > maxError * 0.15f, $"bits={bits}: MaxError {maxError} absurdly loose vs observed {worst}");
+        }
+        // Identity and axis-aligned rotations are exact-ish at every width.
+        var id = QuantizedCodec.UnpackQuat(QuantizedCodec.PackQuat(Quaternion.Identity, 10), 10);
+        Assert.True(Quaternion.Identity.AngleTo(id) < 1e-3f, $"identity decoded as {id}");
+    }
+
+    // ───────────── MaxError for the grid types ─────────────
+
+    [NebulaUnitTest]
+    public void MaxError_GridTypes_BoundBruteForce()
+    {
+        var rng = new Random(11);
+        const float step = 0.01f;
+        float worst3 = 0f, worst2 = 0f, worst1 = 0f;
+        Span<int> codes = stackalloc int[3];
+        for (int i = 0; i < 5000; i++)
+        {
+            var v = new Vector3((float)rng.NextDouble() * 200 - 100, (float)rng.NextDouble() * 200 - 100, (float)rng.NextDouble() * 200 - 100);
+            var c3 = new PropertyCache { Type = SerialVariantType.Vector3, Vec3Value = v };
+            QuantizedCodec.Canonicalize(ref c3, SerialVariantType.Vector3, false, step);
+            worst3 = MathF.Max(worst3, (c3.Vec3Value - v).Length());
+            var c2 = new PropertyCache { Type = SerialVariantType.Vector2, Vec2Value = new Vector2(v.X, v.Y) };
+            QuantizedCodec.Canonicalize(ref c2, SerialVariantType.Vector2, false, step);
+            worst2 = MathF.Max(worst2, (c2.Vec2Value - new Vector2(v.X, v.Y)).Length());
+            var c1 = new PropertyCache { Type = SerialVariantType.Float, FloatValue = v.Z };
+            QuantizedCodec.Canonicalize(ref c1, SerialVariantType.Float, false, step);
+            worst1 = MathF.Max(worst1, MathF.Abs(c1.FloatValue - v.Z));
+        }
+        // Float32 representation of the product adds a relative 1e-7 on top of the grid.
+        const float slack = 1.001f;
+        Assert.True(worst3 <= QuantizedCodec.MaxError(SerialVariantType.Vector3, false, step) * slack);
+        Assert.True(worst2 <= QuantizedCodec.MaxError(SerialVariantType.Vector2, false, step) * slack);
+        Assert.True(worst1 <= QuantizedCodec.MaxError(SerialVariantType.Float, false, step) * slack);
+        Assert.True(worst1 > step * 0.4f, "float sample never approached a half step - test is not exercising the bound");
+    }
+
+    private static bool BitEqual(Vector3 a, Vector3 b)
+        => BitConverter.SingleToInt32Bits(a.X) == BitConverter.SingleToInt32Bits(b.X)
+        && BitConverter.SingleToInt32Bits(a.Y) == BitConverter.SingleToInt32Bits(b.Y)
+        && BitConverter.SingleToInt32Bits(a.Z) == BitConverter.SingleToInt32Bits(b.Z);
+}

--- a/addons/Nebula/Testing/Unit/QuantizedCodecTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/QuantizedCodecTests.cs.uid
@@ -1,0 +1,1 @@
+uid://rw5viryomcd5


### PR DESCRIPTION
NetProperty gains Quantize (grid step) and UnitVector (octahedral Vector3). Quantized values replicate as integer step counts via QuantizedCodec, with absolute, small-packed-delta and full-delta forms; quaternions use smallest-three packing. Changes smaller than one step are not sent.

NetTransform3D defaults to a 1 cm position grid and 10-bit rotation components. Quantize and UnitVector are part of the protocol hash, and the generator reports NEBULA010 for unsupported types or PerPeerState combos.