### PR TITLE
Send interest resync on change and resend until acked

### DIFF
--- a/addons/Nebula/Core/Diagnostics/TickProfiler.cs
+++ b/addons/Nebula/Core/Diagnostics/TickProfiler.cs
@@ -188,6 +188,13 @@ namespace Nebula.Diagnostics
             /// sent" x peers - the latter is what the pre-ring pending set cost.
             /// </summary>
             AckNodesVisited,
+            /// <summary>Interest resync sections committed (phase 3), summed over peers.</summary>
+            ResyncSections,
+            /// <summary>
+            /// Wire bytes those sections cost INCLUDING framing (node header, group header) -
+            /// the only attribution of resync cost; PayloadCensus never sees these bytes.
+            /// </summary>
+            ResyncBytes,
             Count,
         }
 
@@ -197,6 +204,7 @@ namespace Nebula.Diagnostics
             "pk_chosen_age_sum", "pk_measured",
             "memo_hit", "memo_miss", "memo_slow", "memo_overflow",
             "ack_nodes_visited",
+            "resync_sections", "resync_bytes",
         };
         private const int CounterCount = (int)Counter.Count;
 

--- a/addons/Nebula/Core/Serialization/Serializers/InterestResyncSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/InterestResyncSerializer.cs
@@ -1,21 +1,78 @@
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Godot;
 
 namespace Nebula.Serialization.Serializers
 {
     /// <summary>
-    /// Serializer that syncs interest state to clients at a staggered interval.
-    /// Writes 1 byte (0 or 1) to indicate interest state.
-    /// Staggered by node ID to spread network load across ticks.
+    /// Tells each peer whether it currently has interest in this node, as one byte (1/0),
+    /// sent ON CHANGE and resent every tick until the peer acks a packet that carried it.
+    ///
+    /// <para>This used to be a periodic repeat (every node, every peer, every 3 ticks,
+    /// unconditionally) because it kept no per-peer state and healed packet loss by simply
+    /// sending again. The byte was never the cost: a section pays framing (a node header,
+    /// and a group header when it opens one), so an idle node paid 2 to 10 bytes per peer
+    /// every 100 ms as a permanent floor that scaled with scene count, not activity. The ack
+    /// ring (<see cref="SentNodeRing"/>) now routes acks to exactly the nodes in a packet, so
+    /// the spawn serializer's resend-until-acked contract (<see cref="SendWindow"/>) is cheap
+    /// enough to reuse here, and an idle node costs nothing.</para>
+    ///
+    /// <para><b>Baseline.</b> A node is only ever spawned for a peer that has interest in it
+    /// (SpawnSerializer refuses otherwise), so both sides start from "interested" at spawn:
+    /// the server's per-peer state initialises <c>Acked = true</c> and the client's
+    /// <c>clientHasInterest</c> starts true. A respawn resets the server side through
+    /// <see cref="ResetPeerBaseline"/>.</para>
+    ///
+    /// <para><b>Detection.</b> Interest is evaluated on the node's stagger slot (once per
+    /// <see cref="SYNC_INTERVAL"/> ticks, as before) by comparing the computed
+    /// <c>IsPeerInterested</c> against the value the peer provably holds - not by listening
+    /// to <c>InterestChanged</c>, which peer-set writes (AddInterestPeer / RemoveInterestPeer)
+    /// never fire. While anything is in flight the node is evaluated every tick.</para>
+    ///
+    /// <para><b>The flip-back trap.</b> If interest is lost, the 0 ships, the peer applies it
+    /// and only the ack is lost, and interest is then regained, a naive "desired equals acked,
+    /// nothing to do" would strand the peer with a hidden node forever. So a value stays in
+    /// flight until an ack proves which byte the peer holds; a change while in flight restarts
+    /// the window with the new value and keeps sending.</para>
     /// </summary>
     public partial class InterestResyncSerializer : RefCounted, IStateSerializer
     {
-        private const int SYNC_INTERVAL = 3; // ~10hz at 30 TPS
+        /// <summary>Stagger period, in ticks, of the idle interest check (~10 Hz at 30 TPS).</summary>
+        private const int SYNC_INTERVAL = 3;
+
+        private const byte InterestedByte = 1;
+        private const byte NotInterestedByte = 0;
+        private const int SectionBytes = 1;
 
         private NetworkController network;
 
-        // Client-side: tracks current interest state
-        private bool clientHasInterest = false;
+        // Client-side: the value last applied. Starts true (see class doc).
+        private bool clientHasInterest = true;
+
+        /// <summary>Server-side, per peer: what the peer holds, and what is being resent.</summary>
+        private struct PeerInterestState
+        {
+            /// <summary>The value the peer provably holds (spawn implies true).</summary>
+            public bool Acked;
+            /// <summary>The value in the open resend window; meaningful only while InFlight.</summary>
+            public bool Sent;
+            /// <summary>True while a value is being resent and no ack has covered it yet.</summary>
+            public bool InFlight;
+            /// <summary>Ticks the Sent value rode a packet; Covers(ack) commits it.</summary>
+            public SendWindow Window;
+        }
+
+        private Dictionary<UUID, PeerInterestState> _peerStates;
+
+        /// <summary>
+        /// Peers with an in-flight value. Zero is the idle fast path: off the stagger slot the
+        /// serializer returns without touching the dictionary at all.
+        /// </summary>
+        private int _pendingPeers;
+
+        /// <summary>Export wrote a byte for this peer; CommitExport stamps the window.</summary>
+        private bool _pendingCommit;
+        private UUID _pendingCommitPeer;
 
         public InterestResyncSerializer(NetworkController controller)
         {
@@ -24,17 +81,28 @@ namespace Nebula.Serialization.Serializers
 
         public void Begin() { }
         public void Cleanup() { }
-        public void CleanupPeer(UUID peerId) { }
-        public void Acknowledge(WorldRunner currentWorld, NetPeer peer, Tick latestAck) { }
+
+        public void CleanupPeer(UUID peerId) => ForgetPeer(peerId);
+
+        /// <summary>
+        /// The peer is about to receive a fresh copy of this node, whose client-side instance
+        /// starts from "interested" like every spawn; whatever was in flight for the old
+        /// instance is meaningless to the new one.
+        /// </summary>
+        public void ResetPeerBaseline(UUID peerId) => ForgetPeer(peerId);
+
+        private void ForgetPeer(UUID peerId)
+        {
+            if (_peerStates == null) return;
+            if (_peerStates.Remove(peerId, out var state) && state.InFlight)
+            {
+                _pendingPeers--;
+            }
+        }
 
         public ExportResult Export(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer, int maxBytes)
         {
-            // Self-limiting: the section is exactly 1 byte, and a deferred tick is
-            // harmless - there is no ack tracking, the next stagger slot resyncs.
-            if (maxBytes < 1)
-            {
-                return ExportResult.None;
-            }
+            _pendingCommit = false;
 
             // Only sync after the node has been spawned for this peer
             if (!currentWorld.HasSpawnedForClient(network.NetId, peer))
@@ -42,16 +110,86 @@ namespace Nebula.Serialization.Serializers
                 return ExportResult.None;
             }
 
-            // Stagger by node ID so not all nodes sync on same tick
+            // Idle fast path: nothing in flight and not this node's stagger slot. This is
+            // the per-tick cost of the old design (one interest evaluation per node per
+            // SYNC_INTERVAL ticks), minus the byte it used to write.
             int tickOffset = (int)(network.NetId.Value % SYNC_INTERVAL);
-            if ((currentWorld.CurrentTick + tickOffset) % SYNC_INTERVAL != 0)
+            bool staggerSlot = (currentWorld.CurrentTick + tickOffset) % SYNC_INTERVAL == 0;
+            if (_pendingPeers == 0 && !staggerSlot)
             {
                 return ExportResult.None;
             }
 
-            bool isInterested = network.IsPeerInterested(peer);
-            NetWriter.WriteByte(buffer, isInterested ? (byte)1 : (byte)0);
+            var peerId = NetRunner.Instance.GetPeerId(peer);
+            _peerStates ??= new Dictionary<UUID, PeerInterestState>();
+            ref var state = ref CollectionsMarshal.GetValueRefOrAddDefault(_peerStates, peerId, out bool exists);
+            if (!exists)
+            {
+                state.Acked = true;
+            }
+
+            if (!state.InFlight && !staggerSlot)
+            {
+                // Another peer's in-flight value dragged this node onto the every-tick path;
+                // this peer only re-evaluates on the stagger slot.
+                return ExportResult.None;
+            }
+
+            bool desired = network.IsPeerInterested(peer);
+            bool held = state.InFlight ? state.Sent : state.Acked;
+            if (desired != held)
+            {
+                // A new value: restart the window so an ack of a tick that carried the
+                // previous value cannot commit this one.
+                if (!state.InFlight)
+                {
+                    state.InFlight = true;
+                    _pendingPeers++;
+                }
+                state.Sent = desired;
+                state.Window = default;
+            }
+            else if (!state.InFlight)
+            {
+                return ExportResult.None;
+            }
+
+            // Self-limiting: the section is exactly 1 byte. A deferred tick just leaves a gap
+            // in the window (SendWindow restarts across gaps), which is always safe.
+            if (maxBytes < SectionBytes)
+            {
+                return ExportResult.None;
+            }
+
+            NetWriter.WriteByte(buffer, state.Sent ? InterestedByte : NotInterestedByte);
+            _pendingCommit = true;
+            _pendingCommitPeer = peerId;
             return ExportResult.Written;
+        }
+
+        public void CommitExport(WorldRunner currentWorld, NetPeer peer, Tick tick)
+        {
+            if (!_pendingCommit) return;
+            _pendingCommit = false;
+            ref var state = ref CollectionsMarshal.GetValueRefOrNullRef(_peerStates, _pendingCommitPeer);
+            if (System.Runtime.CompilerServices.Unsafe.IsNullRef(ref state)) return;
+            state.Window.RecordSend(tick);
+        }
+
+        public void Acknowledge(WorldRunner currentWorld, NetPeer peer, Tick latestAck)
+        {
+            if (_peerStates == null || _pendingPeers == 0) return;
+            var peerId = NetRunner.Instance.GetPeerId(peer);
+            ref var state = ref CollectionsMarshal.GetValueRefOrNullRef(_peerStates, peerId);
+            if (System.Runtime.CompilerServices.Unsafe.IsNullRef(ref state) || !state.InFlight) return;
+
+            // Commit only when the acked tick's packet provably carried the current value;
+            // an ack for a pre-restart or pre-gap send costs one more resend round.
+            if (!state.Window.Covers(latestAck)) return;
+            state.Acked = state.Sent;
+            state.InFlight = false;
+            state.Window = default;
+            _pendingPeers--;
         }
 
         public bool Import(WorldRunner currentWorld, NetBuffer buffer, out NetworkController nodeOut)
@@ -60,7 +198,7 @@ namespace Nebula.Serialization.Serializers
             if (network == null) return true;
 
             byte interestByte = NetReader.ReadByte(buffer);
-            bool hasInterest = interestByte == 1;
+            bool hasInterest = interestByte == InterestedByte;
 
             // Only fire event if state actually changed
             if (hasInterest != clientHasInterest)
@@ -70,5 +208,11 @@ namespace Nebula.Serialization.Serializers
             }
             return true;
         }
+
+        /// <summary>Test seam: peers with a value in flight.</summary>
+        internal int PendingPeersForTests => _pendingPeers;
+
+        /// <summary>Test seam: whether any per-peer state exists for this peer.</summary>
+        internal bool HasPeerStateForTests(UUID peerId) => _peerStates != null && _peerStates.ContainsKey(peerId);
     }
 }

--- a/addons/Nebula/Core/Serialization/TickBudgetLedger.cs
+++ b/addons/Nebula/Core/Serialization/TickBudgetLedger.cs
@@ -35,6 +35,10 @@ namespace Nebula.Serialization
         private static int FramingCost(bool firstSectionForNode, bool opensNewGroup)
             => (firstSectionForNode ? 1 : 0) + (opensNewGroup ? 8 : 0);
 
+        /// <summary>Framing a section paid, for byte attribution in diagnostics counters.</summary>
+        public static int FramingCostForDiagnostics(bool firstSectionForNode, bool opensNewGroup)
+            => FramingCost(firstSectionForNode, opensNewGroup);
+
         /// <summary>
         /// Max section payload bytes that can still be committed for a node with the given
         /// framing situation. Never negative.

--- a/addons/Nebula/Core/WorldRunner.cs
+++ b/addons/Nebula/Core/WorldRunner.cs
@@ -3629,16 +3629,24 @@ namespace Nebula
                     }
 
                     bool first = !NodeIdUtils.IsBitSet(_updatedNodesMask, localNodeId);
+                    bool opensGroup = first && GroupIsClosed(localNodeId);
                     _tempSerializerBuffer.Reset();
                     var result = serializer.Export(this, peer, _tempSerializerBuffer,
-                        ledger.SectionBudget(first, first && GroupIsClosed(localNodeId)));
+                        ledger.SectionBudget(first, opensGroup));
                     if (result == ExportResult.None || _tempSerializerBuffer.WritePosition == 0)
                     {
                         continue;
                     }
+                    int resyncSectionBytes = _tempSerializerBuffer.WritePosition;
                     if (!TryAppendSection(netController, localNodeId, InterestResyncSerializerIndex, ref ledger))
                     {
-                        continue; // dropped: the next stagger slot resyncs, no ack state
+                        continue; // dropped: resent next tick, no packet-coupled state stamped
+                    }
+                    if (_profiler != null)
+                    {
+                        _profiler.Add(Diagnostics.TickProfiler.Counter.ResyncSections, 1);
+                        _profiler.Add(Diagnostics.TickProfiler.Counter.ResyncBytes,
+                            resyncSectionBytes + TickBudgetLedger.FramingCostForDiagnostics(first, opensGroup));
                     }
                     serializer.CommitExport(this, peer, CurrentTick);
                 }

--- a/addons/Nebula/ENet/ENet.cs.uid
+++ b/addons/Nebula/ENet/ENet.cs.uid
@@ -1,0 +1,1 @@
+uid://d2cn30ntbm26m

--- a/addons/Nebula/ENet/ENetNativeResolver.cs.uid
+++ b/addons/Nebula/ENet/ENetNativeResolver.cs.uid
@@ -1,0 +1,1 @@
+uid://bkgkb6v6jnjat

--- a/addons/Nebula/Testing/Unit/InterestResyncTests.cs
+++ b/addons/Nebula/Testing/Unit/InterestResyncTests.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using Nebula;
+using Nebula.Serialization;
+using Nebula.Serialization.Serializers;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// The interest resync serializer as send-on-change with resend-until-acked. The failure
+/// modes that matter: an idle node paying anything at all, a lost ack stranding a peer on the
+/// wrong value (the flip-back trap), and a window leaking so the node never returns to the
+/// idle fast path. Every scenario ends by asserting the pending count is back to zero.
+///
+/// Interest is driven through the peer's InterestLayers directly: layers == 0 is "no
+/// interest" in NetworkController.IsPeerInterested, and the test node has no [NetInterest]
+/// scene entry, so any nonzero value is "interested".
+/// </summary>
+[NebulaUnitTest]
+public class InterestResyncTests
+{
+    private const int Interval = 3; // InterestResyncSerializer.SYNC_INTERVAL
+
+    private sealed class Fixture : IDisposable
+    {
+        public WorldRunner World;
+        public NetPeer Peer;
+        public UUID PeerId;
+        public NetNode Node;
+        public InterestResyncSerializer Server;
+
+        public Fixture()
+        {
+            World = new WorldRunner();
+            Peer = default;
+            PeerId = UUID.NewUUID();
+            NetRunner.Instance.PeerIds[0] = PeerId;
+            World.CreatePeerStateForTests(Peer, PeerId);
+
+            Node = new NetNode();
+            Node.Network.InterestLayers[PeerId] = 1;
+            Node.Network.CurrentWorld = World;
+            Server = new InterestResyncSerializer(Node.Network);
+            World.SetClientSpawnState(Node.Network.NetId, Peer, WorldRunner.ClientSpawnState.Spawned);
+        }
+
+        public void SetInterest(bool interested) => Node.Network.InterestLayers[PeerId] = interested ? 1 : 0;
+
+        /// <summary>The node's stagger slot: the first tick at or after <paramref name="from"/> that evaluates.</summary>
+        public int NextSlot(int from)
+        {
+            int offset = (int)(Node.Network.NetId.Value % Interval);
+            int tick = from;
+            while ((tick + offset) % Interval != 0) tick++;
+            return tick;
+        }
+
+        /// <summary>Export at a tick; returns the byte written, or -1 for nothing. Commits when written.</summary>
+        public int Tick(int tick, int maxBytes = int.MaxValue)
+        {
+            World.CurrentTick = tick;
+            var buf = new NetBuffer(8, usePool: false);
+            var result = Server.Export(World, Peer, buf, maxBytes);
+            if (result == ExportResult.None)
+            {
+                Assert.Equal(0, buf.Length);
+                return -1;
+            }
+            Assert.Equal(1, buf.Length);
+            Server.CommitExport(World, Peer, tick);
+            return buf.WrittenSpan[0];
+        }
+
+        public void Ack(int tick) => Server.Acknowledge(World, Peer, tick);
+
+        public void Dispose()
+        {
+            NetRunner.Instance.PeerIds.Remove(0);
+            Node.Free();
+            World.Free();
+        }
+    }
+
+    // 1. Idle: an interested peer is never sent anything, on or off the stagger slot.
+    [NebulaUnitTest]
+    public void Idle_NeverShips()
+    {
+        using var f = new Fixture();
+        for (int tick = 1; tick <= 200; tick++) Assert.Equal(-1, f.Tick(tick));
+        Assert.Equal(0, f.Server.PendingPeersForTests);
+    }
+
+    // 2. Loss: detected on the next stagger slot, resent every tick, stopped by a covering ack.
+    [NebulaUnitTest]
+    public void Loss_ShipsOnSlot_ResendsUntilCoveredAck()
+    {
+        using var f = new Fixture();
+        Assert.Equal(-1, f.Tick(1));
+        f.SetInterest(false);
+
+        int slot = f.NextSlot(2);
+        for (int tick = 2; tick < slot; tick++) Assert.Equal(-1, f.Tick(tick));
+        Assert.Equal(0, f.Tick(slot));
+        Assert.Equal(1, f.Server.PendingPeersForTests);
+        Assert.Equal(0, f.Tick(slot + 1));   // every tick now, not just the slot
+        Assert.Equal(0, f.Tick(slot + 2));
+
+        f.Ack(slot - 1);                     // outside the window: ignored
+        Assert.Equal(1, f.Server.PendingPeersForTests);
+        Assert.Equal(0, f.Tick(slot + 3));
+
+        f.Ack(slot + 1);                     // covered: committed
+        Assert.Equal(0, f.Server.PendingPeersForTests);
+        for (int tick = slot + 4; tick <= slot + 40; tick++) Assert.Equal(-1, f.Tick(tick));
+    }
+
+    // 3. The flip-back trap: interest regained while the loss is unacked must keep sending
+    //    the new value until IT is acked, and an ack for the old value's tick must not stop it.
+    [NebulaUnitTest]
+    public void FlipBackWhileInFlight_KeepsSendingNewValueUntilAcked()
+    {
+        using var f = new Fixture();
+        f.SetInterest(false);
+        int t = f.NextSlot(1);
+        Assert.Equal(0, f.Tick(t));
+        Assert.Equal(0, f.Tick(t + 1));
+        Assert.Equal(0, f.Tick(t + 2));
+
+        f.SetInterest(true);                 // back to the value the peer "already holds"
+        Assert.Equal(1, f.Tick(t + 3));      // still ships: only an ack says what the peer has
+        Assert.Equal(1, f.Tick(t + 4));
+
+        f.Ack(t + 1);                        // the 0's window was restarted; this proves nothing
+        Assert.Equal(1, f.Server.PendingPeersForTests);
+        Assert.Equal(1, f.Tick(t + 5));
+
+        f.Ack(t + 4);
+        Assert.Equal(0, f.Server.PendingPeersForTests);
+        for (int tick = t + 6; tick <= t + 30; tick++) Assert.Equal(-1, f.Tick(tick));
+    }
+
+    // 4. Budget deferral mid-window: the gap restarts the window, so an ack for a pre-gap
+    //    tick does not commit; the post-gap send does.
+    [NebulaUnitTest]
+    public void Deferral_RestartsWindow()
+    {
+        using var f = new Fixture();
+        f.SetInterest(false);
+        int t = f.NextSlot(1);
+        Assert.Equal(0, f.Tick(t));
+        Assert.Equal(0, f.Tick(t + 1));
+        Assert.Equal(-1, f.Tick(t + 2, maxBytes: 0));   // deferred, nothing committed
+        Assert.Equal(0, f.Tick(t + 3));
+
+        f.Ack(t + 1);                        // pre-gap
+        Assert.Equal(1, f.Server.PendingPeersForTests);
+        f.Ack(t + 3);
+        Assert.Equal(0, f.Server.PendingPeersForTests);
+    }
+
+    // 5. A respawn resets the peer to the spawn baseline: an uninterested peer is told again.
+    [NebulaUnitTest]
+    public void ResetPeerBaseline_ForgetsInFlight_AndRestartsFromInterested()
+    {
+        using var f = new Fixture();
+        f.SetInterest(false);
+        int t = f.NextSlot(1);
+        Assert.Equal(0, f.Tick(t));
+        Assert.Equal(1, f.Server.PendingPeersForTests);
+
+        f.Server.ResetPeerBaseline(f.PeerId);
+        Assert.Equal(0, f.Server.PendingPeersForTests);
+        Assert.False(f.Server.HasPeerStateForTests(f.PeerId));
+
+        // Fresh instance assumes interest; the loss is re-detected on the next slot.
+        int next = f.NextSlot(t + 1);
+        for (int tick = t + 1; tick < next; tick++) Assert.Equal(-1, f.Tick(tick));
+        Assert.Equal(0, f.Tick(next));
+        f.Ack(next);
+        Assert.Equal(0, f.Server.PendingPeersForTests);
+
+        f.Server.CleanupPeer(f.PeerId);
+        Assert.False(f.Server.HasPeerStateForTests(f.PeerId));
+    }
+
+    // 6. Client: starts interested; fires only on a change.
+    [NebulaUnitTest]
+    public void Client_StartsInterested_FiresOnlyOnChange()
+    {
+        var node = new NetNode();
+        try
+        {
+            var client = new InterestResyncSerializer(node.Network);
+            var fired = new List<bool>();
+            node.Network.OnInterestChanged += v => fired.Add(v);
+
+            Assert.True(client.Import(null, Wire(1), out _));
+            Assert.Empty(fired);                        // already interested
+            Assert.True(client.Import(null, Wire(0), out _));
+            Assert.Equal(new[] { false }, fired);
+            Assert.True(client.Import(null, Wire(0), out _));
+            Assert.Equal(new[] { false }, fired);       // duplicate resend: no re-fire
+            Assert.True(client.Import(null, Wire(1), out _));
+            Assert.Equal(new[] { false, true }, fired);
+        }
+        finally
+        {
+            node.Free();
+        }
+    }
+
+    private static NetBuffer Wire(byte b)
+    {
+        var buf = new NetBuffer(8, usePool: false);
+        NetWriter.WriteByte(buf, b);
+        buf.ResetRead();
+        return buf;
+    }
+}

--- a/addons/Nebula/Testing/Unit/InterestResyncTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/InterestResyncTests.cs.uid
@@ -1,0 +1,1 @@
+uid://dqw0uvbyt7ct1

--- a/addons/Nebula/Testing/Unit/PeerAckRingTests.cs
+++ b/addons/Nebula/Testing/Unit/PeerAckRingTests.cs
@@ -132,6 +132,39 @@ public class PeerAckRingTests
         Assert.Equal(new[] { wrapTick }, recentRec.AckedTicks);
     }
 
+    // 2b. A node whose ONLY section was the interest resync byte is acked through the ring
+    //     like any other: the resync serializer's resend-until-acked commit depends on it.
+    [NebulaUnitTest]
+    public void Ack_ReachesResyncOnlySection()
+    {
+        using var f = new Fixture();
+        var node = new NetNode();
+        node.Network.CurrentWorld = f.World;
+        node.Network.InterestLayers[f.PeerId] = 1;
+        f.Nodes.Add(node);
+        var resync = new InterestResyncSerializer(node.Network);
+        node.SetSerializersForTests([resync]);
+        f.World.SetClientSpawnState(node.Network.NetId, f.Peer, WorldRunner.ClientSpawnState.Spawned);
+
+        // Interest lost: find the stagger slot, export + commit there (what phase 3 does).
+        node.Network.InterestLayers[f.PeerId] = 0;
+        int tick = 10;
+        var buf = new NetBuffer(8, usePool: false);
+        while (true)
+        {
+            f.World.CurrentTick = tick;
+            buf.Reset();
+            if (resync.Export(f.World, f.Peer, buf, int.MaxValue) == ExportResult.Written) break;
+            tick++;
+        }
+        resync.CommitExport(f.World, f.Peer, tick);
+        f.World.RegisterSentNodeForTests(f.PeerId, tick, node.Network);
+        Assert.Equal(1, resync.PendingPeersForTests);
+
+        f.World.PeerAcknowledge(f.Peer, tick);
+        Assert.Equal(0, resync.PendingPeersForTests);
+    }
+
     // 3. A node freed between commit and ack is skipped, not acked into a dead serializer.
     [NebulaUnitTest]
     public void Ack_SkipsNodeMarkedForDeletion()


### PR DESCRIPTION
InterestResyncSerializer replaces the unconditional every-3-tick repeat with per-peer state: the byte is written when the computed interest differs from what the peer provably holds, then resent each tick until an ack covers the send window. Spawn implies interested on both sides, and ResetPeerBaseline clears state on respawn. An idle node now costs no bytes instead of paying node/group framing per peer every 100 ms.

Adds ResyncSections and ResyncBytes profiler counters, with framing included via TickBudgetLedger.FramingCostForDiagnostics, plus InterestResyncTests.