### PR TITLE
Update integration tests to new compiler

### DIFF
--- a/test/Integration/Basic/Player.cs
+++ b/test/Integration/Basic/Player.cs
@@ -52,7 +52,7 @@ public partial class Player : NetNode3D
     public override void _NetworkProcess(int tick)
     {
         base._NetworkProcess(tick);
-        if (!NetRunner.Instance.IsServer) return;
+        if (!NetRunner.IsServer) return;
 
         ref readonly var input = ref Network.GetInput<TestInput>();
         

--- a/test/Integration/Basic/Scene.cs
+++ b/test/Integration/Basic/Scene.cs
@@ -33,7 +33,7 @@ public partial class Scene : NetNode3D
         if (command.StartsWith("Input:"))
         {
             // Only the client should handle input commands (clients set input, server receives it)
-            if (NetRunner.Instance.IsServer) return;
+            if (NetRunner.IsServer) return;
             
             var inputParts = command.Substring("Input:".Length).Trim().Split(':');
             if (inputParts.Length != 2)
@@ -82,7 +82,7 @@ public partial class Scene : NetNode3D
         if (command == "CanDespawnNodes")
         {
             verifyingDespawn = true;
-            if (NetRunner.Instance.IsClient)
+            if (NetRunner.IsClient)
             {
                 return;
             }

--- a/test/project.godot
+++ b/test/project.godot
@@ -10,6 +10,7 @@ config_version=5
 
 [Nebula]
 
+config/build/bson_support=true
 config/log_level=8
 
 [application]


### PR DESCRIPTION
We introduced aggressive build trimming, including ability to exclude BSON support, and static branching for Roslyn to prune dead branches. Integration tests need updating to follow suit.